### PR TITLE
Receptionist routes to the best agent for initial user input

### DIFF
--- a/pilot/const/function_calls.py
+++ b/pilot/const/function_calls.py
@@ -112,6 +112,29 @@ COMMANDS_TO_RUN = {
     },
 }
 
+ROUTE_INITIAL_INPUT = {
+    'definitions': [
+        {
+            'name': 'route_initial_input',
+            'description': 'Routes the user to the agent best suited to handle a call.',
+            'parameters': {
+                'type': 'object',
+                'properties': {
+                    'agent': {
+                        'type': 'string',
+                        'description': 'Name of the agent that is best suited to handle a call.',
+                        'enum': ['ProductOwner', 'Architect', 'TechLead', 'Developer', 'CodeMonkey'],
+                    },
+                },
+                'required': ['agent'],
+            },
+        },
+    ],
+    'functions': {
+        'route_initial_input': lambda agent: agent
+    },
+}
+
 DEV_TASKS_BREAKDOWN = {
     'definitions': [
         {

--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -42,6 +42,7 @@ class AgentConvo:
         # craft message
         self.construct_and_add_message_from_prompt(prompt_path, prompt_data)
 
+        # TODO: should all of this move into the Developer class?
         # check if we already have the LLM response saved
         if self.agent.__class__.__name__ == 'Developer':
             self.agent.project.llm_req_num += 1

--- a/pilot/helpers/agents/Receptionist.py
+++ b/pilot/helpers/agents/Receptionist.py
@@ -1,0 +1,15 @@
+from helpers.Agent import Agent
+from helpers.AgentConvo import AgentConvo
+from const.function_calls import ROUTE_INITIAL_INPUT
+
+
+class Receptionist(Agent):
+    def __init__(self, project):
+        super().__init__('receptionist', project)
+        self.convo = AgentConvo(self)
+
+    def route_initial_input(self, user_input: str):
+        route = self.convo.send_message('routing/route_initial_input.prompt',
+                                   {'input': user_input},
+                                   ROUTE_INITIAL_INPUT)
+        return route

--- a/pilot/helpers/agents/test_Receptionist.py
+++ b/pilot/helpers/agents/test_Receptionist.py
@@ -25,7 +25,8 @@ class TestReceptionist:
 
         self.receptionist = Receptionist(self.project)
 
-    def test_route_ProductOwner(self):
+    @patch('helpers.AgentConvo.get_development_step_from_hash_id', return_value=None)
+    def test_route_ProductOwner(self, mock_get_dev):
         # Given
         mock_value = {'function_calls': {'arguments': {'agent': 'ProductOwner'}, 'name': 'route_initial_input'}}
 
@@ -35,7 +36,8 @@ class TestReceptionist:
         # Then
         assert route == 'ProductOwner'
 
-    def test_route_CodeMonkey(self):
+    @patch('helpers.AgentConvo.get_development_step_from_hash_id', return_value=None)
+    def test_route_CodeMonkey(self, mock_get_dev):
         # Given
         mock_value = {'function_calls': {'arguments': {'agent': 'CodeMonkey'}, 'name': 'route_initial_input'}}
 

--- a/pilot/helpers/agents/test_Receptionist.py
+++ b/pilot/helpers/agents/test_Receptionist.py
@@ -37,6 +37,17 @@ class TestReceptionist:
         assert route == 'ProductOwner'
 
     @patch('helpers.AgentConvo.get_development_step_from_hash_id', return_value=None)
+    def test_route_TechLead_by_name_with_spaces(self, mock_get_dev):
+        # Given
+        mock_value = {'function_calls': {'arguments': {'agent': 'TechLead'}, 'name': 'route_initial_input'}}
+
+        # When
+        route = self.call_route_initial_input('I want to speak with the tech lead', mock_value)
+
+        # Then
+        assert route == 'TechLead'
+
+    @patch('helpers.AgentConvo.get_development_step_from_hash_id', return_value=None)
     def test_route_CodeMonkey(self, mock_get_dev):
         # Given
         mock_value = {'function_calls': {'arguments': {'agent': 'CodeMonkey'}, 'name': 'route_initial_input'}}

--- a/pilot/helpers/agents/test_Receptionist.py
+++ b/pilot/helpers/agents/test_Receptionist.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+from dotenv import load_dotenv
+from .Receptionist import Receptionist
+from helpers.Project import Project
+from utils.test_utils import mock_terminal_size
+
+load_dotenv()
+SEND_TO_LLM = False
+
+
+@patch('os.get_terminal_size', mock_terminal_size)
+class TestReceptionist:
+    def setup_method(self):
+        name = 'TestReceptionist'
+        self.project = Project({
+                'app_id': 'test-receptionist',
+                'name': name,
+                'app_type': ''
+            },
+            name=name,
+            architecture=[],
+            user_stories=[],
+            current_step='',
+        )
+
+        self.receptionist = Receptionist(self.project)
+
+    def test_route_ProductOwner(self):
+        # Given
+        mock_value = {'function_calls': {'arguments': {'agent': 'ProductOwner'}, 'name': 'route_initial_input'}}
+
+        # When
+        route = self.call_route_initial_input('A simple chat app with real time communication', mock_value)
+
+        # Then
+        assert route == 'ProductOwner'
+
+    def test_route_CodeMonkey(self):
+        # Given
+        mock_value = {'function_calls': {'arguments': {'agent': 'CodeMonkey'}, 'name': 'route_initial_input'}}
+
+        # When
+        route = self.call_route_initial_input('Write the word "Washington" to a .txt file', mock_value)
+
+        # Then
+        assert route == 'CodeMonkey'
+
+    def call_route_initial_input(self, input_str, mock_return_value=None):
+        if SEND_TO_LLM or mock_return_value is None:
+            return self.receptionist.route_initial_input(input_str)
+        else:
+            with patch('utils.llm_connection.stream_gpt_completion', return_value=mock_return_value):
+                return self.receptionist.route_initial_input(input_str)

--- a/pilot/prompts/routing/route_initial_input.prompt
+++ b/pilot/prompts/routing/route_initial_input.prompt
@@ -1,0 +1,3 @@
+Based on the user's request, decide who would be best suited to handle the call:
+
+``` {{ input }} ```

--- a/pilot/prompts/system_messages/receptionist.prompt
+++ b/pilot/prompts/system_messages/receptionist.prompt
@@ -1,0 +1,6 @@
+You are a receptionist of a software development company. You job is to answer the phone and direct the caller to an agent with the most suitable role to handle the request.
+ProductOwner talks to clients who have a high-level idea for a new software project that they would like to be designed and developed. The ProductOwner gathers requirements from the client and prepares project specifications for the dev team.
+Architect analyses project specifications and selects the most appropriate technologies to be used in a project.
+TechLead breaks down the project requirements into smaller tasks for the developers.
+Developer implements tasks defined by the TechLead and develops modular code.
+CodeMonkey reads files and implements changes.

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -25,6 +25,8 @@ def get_prompt(prompt_name, data=None):
     if data is None:
         data = {}
 
+    # TODO: move this back out to the Agent, Receptionist doesn't need `no_micro_services` and `single_question`.
+    #       Also, this breaks the Single Responsibility Principle. It should just get the prompt as suggested by the function name.
     data.update(get_prompt_components())
 
     logger.debug(f"Getting prompt for {prompt_name}")  # logging here

--- a/pilot/utils/test_utils.py
+++ b/pilot/utils/test_utils.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 from .utils import should_execute_step
 
 
@@ -17,3 +18,9 @@ class TestShouldExecuteStep:
         assert should_execute_step('unknown', 'project_description') is False
         assert should_execute_step('unknown', None) is False
         assert should_execute_step(None, None) is False
+
+
+def mock_terminal_size():
+    mock_size = Mock()
+    mock_size.columns = 80  # or whatever width you want
+    return mock_size


### PR DESCRIPTION
Implementation for #91 

> Write the word 'Washington' to a .txt file

Can go straight to `CodeMonkey` so that we can be benchmarked against ChatGPT agents.

> A simple chat app with real time communication

Needs to go to the `ProductOwner`.

# Introducing the Receptionist into the conversation
NOTE - This isn't wired up yet. To pass the benchmarks, The `Receptionist` needs to take the first user input prompt.

The problem is that the call flow, by default goes:

- PO: What is the project name?
- User: My App
- PO: Describe your app in as many details as possible.
- User: A simple chat app with real time communication

It would need to be changed to:

- PO: Describe your app in as many details as possible.
- User: A simple chat app with real time communication
( PO asks Receptionist "do you think they want to speak to me or the Code Monkey?" )
- PO: What is the project name?
- User: My App

Or:

- Reception: Hi, how can I help you?
- User: I want to build a web app
- PO: What is the project name?
- User: My App
- PO: Describe your app in as many details as possible.
- User: A simple chat app with real time communication

Or:

- Reception: Would you like to build a new project or 
- User: I want to build a web app
- PO: What is the project name?
- User: My App
- PO: Describe your app in as many details as possible.
- User: A simple chat app with real time communication

# Agent Protocol
I'm also thinking how the Agent Protocol (#89) would work. My original thinking was:

An IDE "New Project" wizard could have a UI which asked for the the following and sent them as sequential `input`s and possibly `additional_input` fields, but I'm not a big fan of using the `additional_input` as it's something that the client (IDE) needs to know about, but it _could_ be a good mechanism to getting past the Receptionist.

- workspace path: /src/chat-app`
- project name: chat app
- description: A simple chat app with real time communication

```
POST /agent/tasks
{
   "input": "chat app"                      // args.name
   "additional_input": {
     "workspace": "/src/chat-app"   // args.workspace
     "task_type": "Web App"
   }
}
```

Creates an `App` and responds with `app_id` as `task_id`
```> { "task_id": "chat_app" }```

Is it reasonable that the client would know (how) to send the `Description` from the New Project wizard UI?

It's possible that the client just starts off with an empty text box like ChatGPT, but at this stage I'm not sure what the client would be sending in the initial Task post.

We still need to cater for the standard use which seems to be:

- user begins a new conversation without any guidance or prompting from our app or LLM, by `POST /agent/tasks`
- user sends further inputs to `POST /agent/tasks/{task_id}/steps`

The catch is that we're not able to present them with a prompt from our app/LLM until they've POSTed the first `steps` input.

```
POST /agent/tasks/chat_app/steps
{
   "input": "A simple chat app with real time communication"
}
```


