### PR TITLE
Fix building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m venv pilot-env
 RUN /bin/bash -c "source pilot-env/bin/activate"
 
-WORKDIR /usr/src/app/pilot
 RUN pip install -r requirements.txt
+WORKDIR /usr/src/app/pilot
 
 EXPOSE 7681
 CMD ["ttyd", "bash"]


### PR DESCRIPTION
Executing the command `docker compose build` gives me:
```
[+] Building 38.0s (14/14) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 864B                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/python:3                                                                                                                                      1.9s
 => [ 1/10] FROM docker.io/library/python:3@sha256:2e376990a11f1c1e03796d08db0e99c36eadb4bb6491372b227f1e53c3482914                                                                              0.2s
 => => resolve docker.io/library/python:3@sha256:2e376990a11f1c1e03796d08db0e99c36eadb4bb6491372b227f1e53c3482914                                                                                0.0s
 => => sha256:88880bc85b0e3342ff416c796df7ad9079b2805f92a6ebfc5c84ac582fb25de9 2.01kB / 2.01kB                                                                                                   0.0s
 => => sha256:b94d01b4929562a35cdcfe80ca0d5fca222c3fdedf224af9a079dc23157e1363 7.53kB / 7.53kB                                                                                                   0.0s
 => => sha256:2e376990a11f1c1e03796d08db0e99c36eadb4bb6491372b227f1e53c3482914 2.14kB / 2.14kB                                                                                                   0.0s
 => [internal] load build context                                                                                                                                                                0.0s
 => => transferring context: 1.00MB                                                                                                                                                              0.0s
 => [ 2/10] RUN apt-get update &&     apt-get install -y wget &&     wget https://github.com/tsl0922/ttyd/releases/download/1.6.3/ttyd.x86_64 -O /usr/bin/ttyd &&     chmod +x /usr/bin/ttyd &&  5.5s
 => [ 3/10] RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash     && . "/root/.nvm/nvm.sh"     && nvm install node     && nvm use node                         7.1s
 => [ 4/10] WORKDIR /usr/src/app                                                                                                                                                                 0.0s
 => [ 5/10] COPY . .                                                                                                                                                                             0.0s
 => [ 6/10] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                  18.6s
 => [ 7/10] RUN python -m venv pilot-env                                                                                                                                                         3.3s
 => [ 8/10] RUN /bin/bash -c "source pilot-env/bin/activate"                                                                                                                                     0.3s
 => [ 9/10] WORKDIR /usr/src/app/pilot                                                                                                                                                           0.1s
 => ERROR [10/10] RUN pip install -r requirements.txt                                                                                                                                            0.8s
------
 > [10/10] RUN pip install -r requirements.txt:
#0 0.730 ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
------
failed to solve: executor failed running [/bin/sh -c pip install -r requirements.txt]: exit code: 1
```
The step `RUN pip install -r requirements.txt` should be run before `WORKDIR /usr/src/app/pilot`.