### PR TITLE
Resolved color display problem on Windows

### DIFF
--- a/pilot/utils/style.py
+++ b/pilot/utils/style.py
@@ -1,4 +1,6 @@
-from colorama import Fore, Style
+from colorama import Fore, Style, init
+
+init()
 
 def red(text):
     return f'{Fore.RED}{text}{Style.RESET_ALL}'


### PR DESCRIPTION
**Summary:**
Fixes a Colorama color rendering issue on Windows by properly initializing the library.

**Changes Made:**
- Added initialization of Colorama using `colorama.init()` at the beginning of the script.
- Ensured that ANSI escape codes are properly handled in compatible terminals.

**Testing:**
I tested this fix on Windows 10 using Windows Terminal and verified that color rendering is now correct.

**Screenshots:**
Before:
![image](https://github.com/Pythagora-io/gpt-pilot/assets/86030102/4a7defb9-3392-4977-a033-094df8d8a5e5)
After: 
![image](https://github.com/Pythagora-io/gpt-pilot/assets/86030102/dadf5f3e-61cc-49d7-a6a0-673e084f1ebd)
