### PR TITLE
added args to get_sys_message

### DIFF
--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -29,7 +29,7 @@ class AgentConvo:
         self.high_level_step = self.agent.project.current_step
 
         # add system message
-        system_message = get_sys_message(self.agent.role)
+        system_message = get_sys_message(self.agent.role,self.agent.project.args)
         logger.info('\n>>>>>>>>>> System Prompt >>>>>>>>>>\n%s\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>',
                     system_message['content'])
         self.messages.append(system_message)

--- a/pilot/utils/utils.py
+++ b/pilot/utils/utils.py
@@ -84,12 +84,12 @@ def get_prompt_components():
     return prompts_components
 
 
-def get_sys_message(role):
+def get_sys_message(role,args=None):
     """
     :param role: 'product_owner', 'architect', 'dev_ops', 'tech_lead', 'full_stack_developer', 'code_monkey'
     :return: { "role": "system", "content": "You are a {role}... You do..." }
     """
-    content = get_prompt(f'system_messages/{role}.prompt')
+    content = get_prompt(f'system_messages/{role}.prompt',args)
 
     return {
         "role": "system",


### PR DESCRIPTION
For getting System messages  `get_sys_message()` is used. In prompt `prompts/system_messages/architect.prompt` there is an variable {{ app_type }} is used but no arguments is passed.

![image](https://github.com/Pythagora-io/gpt-pilot/assets/81203925/679b29fa-081d-44a3-ba77-2f6214b34ae9)

So when the prompt is created, it is left blank

![image](https://github.com/Pythagora-io/gpt-pilot/assets/81203925/df7903cb-bb31-475a-bdf9-cf83c65b05d3)


So I added arguments to `get_sys_messages()` so that it could used not only for architect, but can be used for all agents if required in future!!

