### PR TITLE
Support Anthropic, Palm, Huggingface, Ollama, TogetherAI, Replicate, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ python main.py app_id=<ID_OF_THE_APP> skip_until_dev_step=0
 ## `update_files_before_start`
 
 
+# Use Anthropic,Huggingface,Palm,Ollama, etc.[Full List](https://docs.litellm.ai/docs/providers)
+
+## Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+## Update GPT-Pilot
+In your .env set the openai endpoint to your local server. 
+
+```
+OPENAI_ENDPOINT=http://0.0.0.0:8000
+OPENAI_API_KEY=my-fake-key
+```
 
 # 🔎 Examples
 


### PR DESCRIPTION
Hi @nalbion @zvone187,

Noticed you're calling the openai chat completions endpoint. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and wanted to see how i could be helpful.

My PR shows users how to call their LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing your openai base to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation.

This makes **no code changes** to your app.

Happy to add additional tests/documentation if the initial PR looks good.