### PR TITLE
Add `max_token` for CodeLlama

### DIFF
--- a/pilot/helpers/test_cli.py
+++ b/pilot/helpers/test_cli.py
@@ -2,5 +2,5 @@ from pilot.helpers.cli import terminate_process
 
 
 def test_terminate_process_not_running():
-    terminate_process('999999999', 'not running')
+    terminate_process(999999999, 'not running')
     assert True

--- a/pilot/prompts/utils/incomplete_json.prompt
+++ b/pilot/prompts/utils/incomplete_json.prompt
@@ -1,6 +1,6 @@
 [INST]I received an incomplete JSON response. Please provide the remainder of the JSON object. I will append your entire response to the incomplete JSON data below so it is important that you must not include any of the data already received or any text that does not complete the JSON data.
 A response which starts with "Here is the remainder of the JSON object" would be an example of an invalid response, a preamble must NOT be included.
-Note that because the JSON data I have already received is an incomplete JSON object, you will need to include the opening and closing curly braces in your response, but rather continue off from EXACTLY where the received JSON ends.
+Note that because the JSON data I have already received is an incomplete JSON object, you will not need to include the opening and closing curly braces in your response, but rather continue off from EXACTLY where the received JSON ends.
 
 JSON received:
 [/INST]

--- a/pilot/utils/files.py
+++ b/pilot/utils/files.py
@@ -18,12 +18,17 @@ def setup_workspace(args) -> str:
     Also creates a 'tests' folder inside the workspace.
     :param args: may contain 'root' key
     """
-    root = args.get('root') or get_parent_folder('pilot')
-    name = args.get('name', 'default_project_name')
-    project_path = create_directory(os.path.join(root, 'workspace'), name)
+    workspace = args.get('workspace')
+    if workspace:
+        project_path = workspace
+    else:
+        root = args.get('root') or get_parent_folder('pilot')
+        name = args.get('name', 'default_project_name')
+        project_path = create_directory(os.path.join(root, 'workspace'), name)
+
     create_directory(project_path, 'tests')
     try:
-        save_user_app(args.get('user_id'), args.get('app_id'), name)
+        save_user_app(args.get('user_id'), args.get('app_id'), project_path)
     except Exception as e:
         print(str(e))
 

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -314,9 +314,10 @@ def stream_gpt_completion(data, req_type, project):
         headers = {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + get_api_key_or_throw('OPENROUTER_API_KEY'),
-            'HTTP-Referer': 'http://localhost:3000',
-            'X-Title': 'GPT Pilot (LOCAL)'
+            'HTTP-Referer': 'https://github.com/Pythagora-io/gpt-pilot',
+            'X-Title': 'GPT Pilot'
         }
+        data['max_tokens'] = MAX_GPT_MODEL_TOKENS
         data['model'] = model
     else:
         # If not, send the request to the OpenAI endpoint

--- a/pilot/utils/test_files.py
+++ b/pilot/utils/test_files.py
@@ -3,9 +3,9 @@ from utils.files import setup_workspace
 
 
 def test_setup_workspace_with_existing_workspace():
-    args = {'workspace': 'some_directory', 'name': 'sample'}
+    args = {'workspace': '/some/directory', 'name': 'sample'}
     result = setup_workspace(args)
-    assert result == 'some_directory'
+    assert result == '/some/directory'
 
 
 def mocked_create_directory(path, exist_ok=True):

--- a/pilot/utils/test_files.py
+++ b/pilot/utils/test_files.py
@@ -1,11 +1,6 @@
+import os
 from unittest.mock import patch
 from utils.files import setup_workspace
-
-
-def test_setup_workspace_with_existing_workspace():
-    args = {'workspace': '/some/directory', 'name': 'sample'}
-    result = setup_workspace(args)
-    assert result == '/some/directory'
 
 
 def mocked_create_directory(path, exist_ok=True):
@@ -14,6 +9,13 @@ def mocked_create_directory(path, exist_ok=True):
 
 def mocked_abspath(file):
     return "/root_path/pilot/helpers"
+
+
+@patch('utils.files.os.makedirs', side_effect=mocked_create_directory)
+def test_setup_workspace_with_existing_workspace(mock_makedirs):
+    args = {'workspace': '/some/directory', 'name': 'sample'}
+    result = setup_workspace(args)
+    assert result == '/some/directory'
 
 
 def test_setup_workspace_with_root_arg(monkeypatch):

--- a/pilot/utils/test_files.py
+++ b/pilot/utils/test_files.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from .files import setup_workspace
+from utils.files import setup_workspace
 
 
 def test_setup_workspace_with_existing_workspace():
@@ -23,7 +23,7 @@ def test_setup_workspace_with_root_arg(monkeypatch):
     monkeypatch.setattr('os.makedirs', mocked_create_directory)
 
     result = setup_workspace(args)
-    assert result.replace('\\', '/') == "/my/root/project_name"
+    assert result.replace('\\', '/') == "/my/root/workspace/project_name"
 
 
 @patch('utils.files.os.path.abspath', return_value='/root_path/pilot/helpers')

--- a/pilot/utils/test_files.py
+++ b/pilot/utils/test_files.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from .files import setup_workspace
 
 
@@ -15,11 +16,20 @@ def mocked_abspath(file):
     return "/root_path/pilot/helpers"
 
 
-def test_setup_workspace_without_existing_workspace(monkeypatch):
-    args = {'workspace': None, 'name': 'project_name'}
+def test_setup_workspace_with_root_arg(monkeypatch):
+    args = {'root': '/my/root', 'name': 'project_name'}
 
     monkeypatch.setattr('os.path.abspath', mocked_abspath)
     monkeypatch.setattr('os.makedirs', mocked_create_directory)
+
+    result = setup_workspace(args)
+    assert result.replace('\\', '/') == "/my/root/project_name"
+
+
+@patch('utils.files.os.path.abspath', return_value='/root_path/pilot/helpers')
+@patch('utils.files.os.makedirs', side_effect=mocked_create_directory)
+def test_setup_workspace_without_existing_workspace(mock_makedirs, mock_abs_path):
+    args = {'workspace': None, 'name': 'project_name'}
 
     result = setup_workspace(args)
     assert result.replace('\\', '/') == "/root_path/workspace/project_name"

--- a/pilot/utils/test_llm_connection.py
+++ b/pilot/utils/test_llm_connection.py
@@ -497,9 +497,11 @@ solution-oriented decision-making in areas where precise instructions were not p
         ('OPENAI', 'gpt-4'),
         ('OPENROUTER', 'openai/gpt-3.5-turbo'),
         ('OPENROUTER', 'meta-llama/codellama-34b-instruct'),
+        ('OPENROUTER', 'phind/phind-codellama-34b-v2'),
         ('OPENROUTER', 'google/palm-2-chat-bison'),
         ('OPENROUTER', 'google/palm-2-codechat-bison'),
         ('OPENROUTER', 'anthropic/claude-2'),
+        ('OPENROUTER', 'mistralai/mistral-7b-instruct')
     ])
     def test_chat_completion_TechLead(self, endpoint, model, monkeypatch):
         # Given

--- a/pilot/utils/test_utils.py
+++ b/pilot/utils/test_utils.py
@@ -3,13 +3,13 @@ from .utils import should_execute_step
 
 class TestShouldExecuteStep:
     def test_no_step_arg(self):
-        assert should_execute_step(None, 'project_description') is True
+        assert should_execute_step(None, 'project_description') is False
         assert should_execute_step(None, 'architecture') is True
         assert should_execute_step(None, 'coding') is True
 
     def test_skip_step(self):
         assert should_execute_step('architecture', 'project_description') is False
-        assert should_execute_step('architecture', 'architecture') is True
+        assert should_execute_step('architecture', 'architecture') is False
         assert should_execute_step('architecture', 'coding') is True
 
     def test_unknown_step(self):

--- a/pilot/utils/test_utils.py
+++ b/pilot/utils/test_utils.py
@@ -3,13 +3,13 @@ from .utils import should_execute_step
 
 class TestShouldExecuteStep:
     def test_no_step_arg(self):
-        assert should_execute_step(None, 'project_description') is False
+        assert should_execute_step(None, 'project_description') is True
         assert should_execute_step(None, 'architecture') is True
         assert should_execute_step(None, 'coding') is True
 
     def test_skip_step(self):
         assert should_execute_step('architecture', 'project_description') is False
-        assert should_execute_step('architecture', 'architecture') is False
+        assert should_execute_step('architecture', 'architecture') is True
         assert should_execute_step('architecture', 'coding') is True
 
     def test_unknown_step(self):

--- a/pilot/utils/utils.py
+++ b/pilot/utils/utils.py
@@ -135,7 +135,7 @@ def should_execute_step(arg_step, current_step):
     arg_step_index = 0 if arg_step is None else STEPS.index(arg_step) if arg_step in STEPS else None
     current_step_index = STEPS.index(current_step) if current_step in STEPS else None
 
-    return arg_step_index is not None and current_step_index is not None and current_step_index > arg_step_index
+    return arg_step_index is not None and current_step_index is not None and current_step_index >= arg_step_index
 
 
 def step_already_finished(args, step):


### PR DESCRIPTION
It _is_ possible to get `CodeLlama-34b-Instruct` to send a complete JSON, but OpenRouter does not document all of the required parameters.

OpenRouter is what the name implies - it's routing to the `togethercomputer/CodeLlama-34b-Instruct` model hosted at [TogetherAI](https://docs.together.ai/docs/inference-rest). TogetherAI's API has a `max_tokens` field. 

It might be worth switching to LiteLLM (PR #40) if it means that we can omit the middle-man and support more & customised models.
