### PR TITLE
Update AgentConvo.py

### DIFF
--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -168,6 +168,9 @@ class AgentConvo:
     def replace_file_content(self, message, file_path, new_content):
         escaped_file_path = re.escape(file_path)
 
+        # Escape any \U in the file path
+        escaped_file_path = escaped_file_path.replace("\\U", "\\\\U")
+
         pattern = rf'\*\*{{ {escaped_file_path} }}\*\*\n```\n(.*?)\n```'
 
         new_section_content = f'**{{ {file_path} }}**\n```\n{new_content}\n```'


### PR DESCRIPTION
Issue #134 
**Fix -** **Escape \U in file paths to prevent KeyError in regular expressions**

This pull request addresses a bug in the replace_file_content method of the AgentConvo class. The bug was causing a KeyError when a file path containing the \U sequence was used in a regular expression. The fix involves escaping the \U sequence in the file path before it's used in the regular expression. This prevents the KeyError from being raised and allows the replace_file_content method to function as expected.