### PR TITLE
format directory tree using fewer tokens, as suggested by GPT4

### DIFF
--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -155,11 +155,12 @@ class Project:
         Returns:
             dict: The directory tree.
         """
-        files = {}
-        if with_descriptions and False:
-            files = File.select().where(File.app_id == self.args['app_id'])
-            files = {snapshot.name: snapshot for snapshot in files}
-        return build_directory_tree(self.root_path + '/', ignore=IGNORE_FOLDERS, files=files, add_descriptions=False)
+        # files = {}
+        # if with_descriptions and False:
+        #     files = File.select().where(File.app_id == self.args['app_id'])
+        #     files = {snapshot.name: snapshot for snapshot in files}
+        # return build_directory_tree_with_descriptions(self.root_path, ignore=IGNORE_FOLDERS, files=files, add_descriptions=False)
+        return build_directory_tree(self.root_path, ignore=IGNORE_FOLDERS)
 
     def get_test_directory_tree(self):
         """

--- a/pilot/helpers/cli.py
+++ b/pilot/helpers/cli.py
@@ -274,7 +274,51 @@ def execute_command(project, command, timeout=None, success_message=None, proces
     return return_value, 'DONE' if was_success else None, process.returncode
 
 
-def build_directory_tree(path, prefix="", ignore=None, is_last=False, files=None, add_descriptions=False):
+def build_directory_tree(path, prefix='', is_root=True, ignore=None):
+    """Build the directory tree structure in a simplified format.
+
+    Args:
+    - path: The starting directory path.
+    - prefix: Prefix for the current item, used for recursion.
+    - is_root: Flag to indicate if the current item is the root directory.
+    - ignore: a list of directories to ignore
+
+    Returns:
+    - A string representation of the directory tree.
+    """
+    output = ""
+    indent = '  '
+
+    if os.path.isdir(path):
+        dir_name = os.path.basename(path)
+        if is_root:
+            output += f'/'
+        else:
+            output += f'{prefix}/{dir_name}'
+
+        # List items in the directory
+        items = os.listdir(path)
+        dirs = [item for item in items if os.path.isdir(os.path.join(path, item)) and item not in ignore]
+        files = [item for item in items if os.path.isfile(os.path.join(path, item))]
+
+        if dirs:
+            output += '\n'
+            for index, dir_item in enumerate(dirs):
+                item_path = os.path.join(path, dir_item)
+                output += build_directory_tree(item_path, prefix + indent, is_root=False, ignore=ignore)
+
+            if files:
+                output += f"{prefix}  {', '.join(files)}\n"
+
+        elif files:
+            output += f": {', '.join(files)}\n"
+        else:
+            output += '\n'
+
+    return output
+
+
+def build_directory_tree_with_descriptions(path, prefix="", ignore=None, is_last=False, files=None):
     """Build the directory tree structure in tree-like format.
 
     Args:
@@ -297,17 +341,19 @@ def build_directory_tree(path, prefix="", ignore=None, is_last=False, files=None
 
     if os.path.isdir(path):
         # It's a directory, add its name to the output and then recurse into it
-        output += prefix + "|-- " + os.path.basename(path) + ((' - ' + files[os.path.basename(path)].description + ' ' if files and os.path.basename(path) in files and add_descriptions else '')) + "/\n"
+        output += prefix + "|-- " + os.path.basename(path) + \
+                  ((' - ' + files[os.path.basename(path)].description + ' ' if files and os.path.basename(path) in files else '')) + "/\n"
 
         # List items in the directory
         items = os.listdir(path)
         for index, item in enumerate(items):
             item_path = os.path.join(path, item)
-            output += build_directory_tree(item_path, prefix + indent, ignore, index == len(items) - 1, files, add_descriptions)
+            output += build_directory_tree_with_descriptions(item_path, prefix + indent, ignore, index == len(items) - 1, files)
 
     else:
         # It's a file, add its name to the output
-        output += prefix + "|-- " + os.path.basename(path) + ((' - ' + files[os.path.basename(path)].description + ' ' if files and os.path.basename(path) in files and add_descriptions else '')) + "\n"
+        output += prefix + "|-- " + os.path.basename(path) + \
+                  ((' - ' + files[os.path.basename(path)].description + ' ' if files and os.path.basename(path) in files else '')) + "\n"
 
     return output
 

--- a/pilot/helpers/cli.py
+++ b/pilot/helpers/cli.py
@@ -292,7 +292,7 @@ def build_directory_tree(path, prefix='', is_root=True, ignore=None):
     if os.path.isdir(path):
         dir_name = os.path.basename(path)
         if is_root:
-            output += f'/'
+            output += '/'
         else:
             output += f'{prefix}/{dir_name}'
 

--- a/pilot/helpers/cli.py
+++ b/pilot/helpers/cli.py
@@ -300,6 +300,8 @@ def build_directory_tree(path, prefix='', is_root=True, ignore=None):
         items = os.listdir(path)
         dirs = [item for item in items if os.path.isdir(os.path.join(path, item)) and item not in ignore]
         files = [item for item in items if os.path.isfile(os.path.join(path, item))]
+        dirs.sort()
+        files.sort()
 
         if dirs:
             output += '\n'

--- a/pilot/helpers/test_Project.py
+++ b/pilot/helpers/test_Project.py
@@ -189,5 +189,6 @@ class TestProjectFileLists:
 
         # Then the files should be saved to the project, but nothing from `.gpt-pilot/`
         assert mock_file.call_count == 7
-        assert mock_file.call_args_list[0][1]['name'] == 'package.json'
-        assert mock_file.call_args_list[1][1]['name'] == 'main.js'
+        files = ['package.json', 'main.js', 'file1.js', 'file2.js', 'bar.js', 'fighters.js', 'other.js']
+        for i in range(7):
+            assert mock_file.call_args_list[i][1]['name'] in files

--- a/pilot/helpers/test_Project.py
+++ b/pilot/helpers/test_Project.py
@@ -132,15 +132,30 @@ class TestProjectFileLists:
 
         # with directories including common.IGNORE_FOLDERS
         src = os.path.join(project.root_path, 'src')
+        foo = os.path.join(project.root_path, 'src/foo')
+        files_no_folders = os.path.join(foo, 'files_no_folders')
         os.makedirs(src, exist_ok=True)
+        os.makedirs(foo, exist_ok=True)
+        os.makedirs(foo + '/empty1', exist_ok=True)
+        os.makedirs(foo + '/empty2', exist_ok=True)
+        os.makedirs(files_no_folders, exist_ok=True)
         for dir in ['.git', '.idea', '.vscode', '__pycache__', 'node_modules', 'venv', 'dist', 'build']:
             os.makedirs(os.path.join(project.root_path, dir), exist_ok=True)
 
         # ...and files
+
         with open(os.path.join(project.root_path, 'package.json'), 'w') as file:
             json.dump({'name': 'test app'}, file, indent=2)
-        with open(os.path.join(src, 'main.js'), 'w') as file:
-            file.write('console.log("Hello World!");')
+        for path in [
+            os.path.join(src, 'main.js'),
+            os.path.join(src, 'other.js'),
+            os.path.join(foo, 'bar.js'),
+            os.path.join(foo, 'fighters.js'),
+            os.path.join(files_no_folders, 'file1.js'),
+            os.path.join(files_no_folders, 'file2.js'),
+        ]:
+            with open(path, 'w') as file:
+                file.write('console.log("Hello World!");')
 
         # and a non-empty .gpt-pilot directory
         project.dot_pilot_gpt.write_project(project)
@@ -150,11 +165,17 @@ class TestProjectFileLists:
         tree = self.project.get_directory_tree()
 
         # Then we should not be including the .gpt-pilot directory or other ignored directories
+        # print('\n' + tree)
         assert tree == '''
-|-- /
-|   |-- package.json
-|   |-- src/
-|   |   |-- main.js
+/
+  /src
+    /foo
+      /empty1
+      /empty2
+      /files_no_folders: file1.js, file2.js
+      bar.js, fighters.js
+    main.js, other.js
+  package.json
 '''.lstrip()
 
     @patch('helpers.Project.DevelopmentSteps.get_or_create', return_value=('test', True))

--- a/pilot/helpers/test_Project.py
+++ b/pilot/helpers/test_Project.py
@@ -188,6 +188,6 @@ class TestProjectFileLists:
         self.project.save_files_snapshot('test')
 
         # Then the files should be saved to the project, but nothing from `.gpt-pilot/`
-        assert mock_file.call_count == 2
+        assert mock_file.call_count == 7
         assert mock_file.call_args_list[0][1]['name'] == 'package.json'
         assert mock_file.call_args_list[1][1]['name'] == 'main.js'


### PR DESCRIPTION
From 

```
|--/
|   |-- src/
|   |   |-- foo/
|   |   |   |-- empty1/
|   |   |   |-- empty2/
|   |   |   |-- files_no_folders/ 
|   |   |   |   |-- file1.js
|   |   |   |   |-- file2.js
|   |   |   |-- bar.js
|   |   |   |-- fighters.js
|   |   |-- main.js
|   |   |-- other.js
|   |-- package.json
```

to

```
/
  /src
    /foo
      /empty1
      /empty2
      /files_no_folders: file1.js, file2.js
      bar.js, fighters.js
    main.js, other.js
  package.json
```