### PR TITLE
Fix missing 'theme' key handling in style configuration

### DIFF
--- a/pilot/utils/arguments.py
+++ b/pilot/utils/arguments.py
@@ -26,11 +26,9 @@ def get_arguments():
         else:
             arguments[arg] = True
 
-    if 'theme' not in arguments:
-        arguments['theme'] = 'dark'
-
     theme_mapping = {'light': style_config.theme.LIGHT, 'dark': style_config.theme.DARK}
-    style_config.set_theme(theme=theme_mapping.get(arguments['theme'], style_config.theme.DARK))
+    theme_value = arguments.get('theme', 'dark')
+    style_config.set_theme(theme=theme_mapping.get(theme_value, style_config.theme.DARK))
 
     if 'user_id' not in arguments:
         arguments['user_id'] = username_to_uuid(getuser())


### PR DESCRIPTION
- Addressed the KeyError when 'theme' is absent in arguments.
- Set the default to 'dark' theme when not specified.
<img width="538" alt="image" src="https://github.com/Pythagora-io/gpt-pilot/assets/138990495/028cbed7-8fea-4e25-814c-5f775c72bfb5">
