### PR TITLE
fix: Create custom_open.py with default encoding set to utf-8

### DIFF
--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -13,6 +13,7 @@ from logger.logger import logger
 from prompts.prompts import ask_user
 from const.llm import END_RESPONSE
 from helpers.cli import running_processes
+from utils.custom_open import open
 
 
 class AgentConvo:
@@ -226,7 +227,7 @@ class AgentConvo:
         })
 
     def to_playground(self):
-        with open('const/convert_to_playground_convo.js', 'r', encoding='utf-8') as file:
+        with open('const/convert_to_playground_convo.js', 'r') as file:
             content = file.read()
         process = subprocess.Popen('pbcopy', stdin=subprocess.PIPE)
         process.communicate(content.replace('{{messages}}', str(self.messages)).encode('utf-8'))

--- a/pilot/helpers/files.py
+++ b/pilot/helpers/files.py
@@ -1,5 +1,6 @@
-from utils.style import color_green
 import os
+from utils.style import color_green
+from utils.custom_open import open
 
 
 def update_file(path, new_content):
@@ -26,7 +27,7 @@ def get_files_content(directory, ignore=[]):
                 continue
 
             path = os.path.join(root, file)
-            with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(path, 'r', errors='ignore') as f:
                 file_content = f.read()
 
             file_name = os.path.basename(path)

--- a/pilot/helpers/test_Project.py
+++ b/pilot/helpers/test_Project.py
@@ -4,6 +4,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 from helpers.Project import Project
 from database.models.files import File
+from utils.custom_open import open
+
 
 test_root = os.path.join(os.path.dirname(__file__), '../../workspace/gpt-pilot-test').replace('\\', '/')
 

--- a/pilot/test/test_custom_open.py
+++ b/pilot/test/test_custom_open.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+from utils.custom_open import open, built_in_open
+
+
+class TestCustomOpenFunction(unittest.TestCase):
+
+    def setUp(self):
+        # This method will be called before each test, we can use it to setup any resources.
+        self.test_filename = "test_file.txt"
+        self.test_content = "This is a test content."
+
+    def tearDown(self):
+        # This method will be called after each test, we can use it to free up any resources or do some cleanup.
+        if os.path.exists(self.test_filename):
+            os.remove(self.test_filename)
+
+    def test_utf8_encoding_by_default(self):
+        # Create a file using the custom open with default encoding
+        with open(self.test_filename, 'w') as f:
+            f.write(self.test_content)
+
+        # Open the file using the built-in open function with utf-8 encoding and check the content
+        with built_in_open(self.test_filename, 'r', encoding='utf-8') as f:
+            content = f.read()
+            self.assertEqual(content, self.test_content)
+
+    def test_explicit_encoding_overrides_default(self):
+        # Write some bytes that are not valid utf-8 to test explicit encoding
+        with built_in_open(self.test_filename, 'wb') as f:
+            f.write(b'\x80abc')
+
+        # Attempt to read using the custom open with default utf-8 encoding should raise an exception
+        with self.assertRaises(UnicodeDecodeError):
+            with open(self.test_filename, 'r') as f:
+                f.read()
+
+        # Reading with explicit 'latin-1' encoding should work
+        with open(self.test_filename, 'r', encoding='latin-1') as f:
+            content = f.read()
+            self.assertEqual(content, '\x80abc')

--- a/pilot/utils/arguments.py
+++ b/pilot/utils/arguments.py
@@ -8,6 +8,7 @@ from database.database import get_app, get_app_by_user_workspace
 from utils.style import color_green_bold, style_config
 from utils.utils import should_execute_step
 from const.common import STEPS
+from utils.custom_open import open
 
 
 def get_arguments():

--- a/pilot/utils/custom_open.py
+++ b/pilot/utils/custom_open.py
@@ -1,0 +1,17 @@
+import builtins
+
+# Save the original 'open' function to avoid infinite recursion
+built_in_open = builtins.open
+
+
+def open(file, *args, **kwargs):
+    # If encoding is not specified, set it to 'utf-8'
+    if 'encoding' not in kwargs:
+        kwargs['encoding'] = 'utf-8'
+
+    # Call the original 'open' function with potentially modified arguments
+    return built_in_open(file, *args, **kwargs)
+
+
+# Override the built-in 'open' with our version
+builtins.open = open

--- a/pilot/utils/dot_gpt_pilot.py
+++ b/pilot/utils/dot_gpt_pilot.py
@@ -3,6 +3,7 @@ import os
 import yaml
 from datetime import datetime
 from dotenv import load_dotenv
+from utils.custom_open import open
 
 load_dotenv()
 


### PR DESCRIPTION
This commit addresses the following tasks:

- Created custom_open.py file, with the default encoding set to utf-8, to provide a custom implementation for the open function.
- Replaced the existing `open` function with the new custom open function to handle file opening operations.
- Added a test function to ensure the correctness and stability of the custom open function.

fix #230 