### PR TITLE
feature: Enhancements to custom open function

### DIFF
--- a/pilot/main.py
+++ b/pilot/main.py
@@ -10,6 +10,7 @@ load_dotenv()
 
 from utils.style import color_red
 from utils.custom_print import get_custom_print
+from utils.custom_open import get_custom_open
 from helpers.Project import Project
 from utils.arguments import get_arguments
 from utils.exit import exit_gpt_pilot
@@ -39,6 +40,8 @@ if __name__ == "__main__":
         # sys.argv.append('--ux-test=' + 'continue_development')
         args = init()
         builtins.print, ipc_client_instance = get_custom_print(args)
+        # Override the built-in 'open' with our version
+        builtins.open = get_custom_open
 
         if '--api-key' in args:
             os.environ["OPENAI_API_KEY"] = args['--api-key']

--- a/pilot/test/test_custom_open.py
+++ b/pilot/test/test_custom_open.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+import builtins
+from utils.custom_open import get_custom_open, built_in_open
+
+builtins.open = get_custom_open
+
+
+class TestCustomOpenFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.test_filename = "test_file.txt"
+        self.test_content = "This is a test content."
+
+    def tearDown(self):
+        if os.path.exists(self.test_filename):
+            os.remove(self.test_filename)
+
+    def test_utf8_encoding_by_default(self):
+        with open(self.test_filename, 'w') as f:
+            f.write(self.test_content)
+
+        with built_in_open(self.test_filename, 'r', encoding='utf-8') as f:
+            content = f.read()
+            self.assertEqual(content, self.test_content)
+
+    def test_explicit_encoding_overrides_default(self):
+        # Write using latin-1 encoding
+        with open(self.test_filename, 'w', encoding='latin-1') as f:
+            f.write('©')
+
+        # Check with latin-1 encoding
+        with built_in_open(self.test_filename, 'r', encoding='latin-1') as f:
+            content = f.read()
+            self.assertEqual(content, '©')
+
+    def test_binary_mode_no_encoding(self):
+        with open(self.test_filename, 'wb') as f:
+            f.write(b'\x80abc')
+
+        with built_in_open(self.test_filename, 'rb') as f:
+            content = f.read()
+            self.assertEqual(content, b'\x80abc')
+
+    def test_read_write_binary_mode(self):
+        # Test combinations like 'r+b'
+        with open(self.test_filename, 'w') as f:
+            f.write(self.test_content)
+
+        with open(self.test_filename, 'r+b') as f:
+            content = f.read().decode('utf-8')
+            self.assertEqual(content, self.test_content)
+            f.write(b' additional content')
+
+        with open(self.test_filename, 'r') as f:
+            content = f.read()
+            expected_content = self.test_content + " additional content"
+            self.assertEqual(content, expected_content)

--- a/pilot/utils/custom_open.py
+++ b/pilot/utils/custom_open.py
@@ -1,0 +1,28 @@
+import builtins
+from typing import IO
+# Save the original 'open' function to avoid infinite recursion
+built_in_open = builtins.open
+
+
+def get_custom_open(file, *args, **kwargs) -> IO:
+    """
+    Custom `open` function with default 'utf-8' encoding unless binary mode or encoding is specified.
+
+    Parameters:
+    - file (str): File to open.
+    - *args: Arguments for built-in open function.
+    - **kwargs: Keyword arguments for built-in open function.
+
+    Returns:
+    IO: File object.
+    """
+
+    # Check for binary mode
+    binary_mode = any('b' in arg for arg in args)
+
+    # Set default encoding to 'utf-8' if not specified and not in binary mode
+    if 'encoding' not in kwargs and not binary_mode:
+        kwargs['encoding'] = 'utf-8'
+
+    # Call the original 'open' function
+    return built_in_open(file, *args, **kwargs)


### PR DESCRIPTION
- Introduced `get_custom_open` for enhanced file opening by setting encoding to `utf-8`.
- Replaced global built-in `open` for consistent behavior.
- Addressed binary mode detection in custom open implementation.
![image](https://github.com/Pythagora-io/gpt-pilot/assets/138990495/94e2165e-afae-40a9-841e-339d98da7e92)

fix https://github.com/Pythagora-io/gpt-pilot/issues/230