### PR TITLE
IGNORE_FOLDERS env variable added

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ After you have Python and (optionally) PostgreSQL installed, follow these steps:
 5. `pip install -r requirements.txt` (install the dependencies)
 6. `cd pilot`
 7. `mv .env.example .env` (create the .env file)
-8. Add your environment (OpenAI/Azure), your API key, and the SQLite/PostgreSQL database info to the `.env` file
-   - to change from SQLite to PostgreSQL in your .env, just set `DATABASE_TYPE=postgres`
+8. Add your environment to the `.env` file:
+   - LLM Provider (OpenAI/Azure/Openrouter)
+   - your API key
+   - database settings: SQLite/PostgreSQL (to change from SQLite to PostgreSQL, just set `DATABASE_TYPE=postgres`)
+   - optionally set IGNORE_FOLDERS for the folders which shouldn't be tracked by GPT Pilot in workspace, useful to ignore folders created by compilers (i.e. `IGNORE_FOLDERS=folder1,folder2,folder3`)
 9. `python db_init.py` (initialize the database)
 10. `python main.py` (start GPT Pilot)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ version: '3'
 services:
     gpt-pilot:
         environment:
-            #OPENAI or AZURE
+            # OPENAI/AZURE/OPENROUTER
             - ENDPOINT=OPENAI
             - OPENAI_API_KEY=
             # - AZURE_API_KEY=
             # - AZURE_ENDPOINT=
-            #In case of Azure endpoint, change this to your deployed model name
+            # - OPENROUTER_API_KEY=
+            # In case of Azure endpoint, change this to your deployed model name
             - MODEL_NAME=gpt-4
             - MAX_TOKENS=8192
             - DATABASE_TYPE=postgres
@@ -16,6 +17,8 @@ services:
             - DB_PORT=5432
             - DB_USER=pilot
             - DB_PASSWORD=pilot
+            # Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)
+            # IGNORE_FOLDERS=folder1,folder2
         volumes:
             - ~/gpt-pilot-workspace:/usr/src/app/workspace
         build:

--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -8,12 +8,14 @@ AZURE_API_KEY=
 AZURE_ENDPOINT=
 
 OPENROUTER_API_KEY=
-OPENROUTER_ENDPOINT=https://openrouter.ai/api/v1/chat/completions
 
 # In case of Azure/OpenRouter endpoint, change this to your deployed model name
 MODEL_NAME=gpt-4
 # MODEL_NAME=openai/gpt-3.5-turbo-16k
 MAX_TOKENS=8192
+
+# Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)
+# IGNORE_FOLDERS=folder1,folder2
 
 # Database
 # DATABASE_TYPE=postgres

--- a/pilot/const/common.py
+++ b/pilot/const/common.py
@@ -34,7 +34,6 @@ IGNORE_FOLDERS = [
     'venv',
     'dist',
     'build',
-    # Used by Rust compiler
     'target'
 ] + [folder for folder in additional_ignore_folders if folder]
 

--- a/pilot/const/common.py
+++ b/pilot/const/common.py
@@ -1,3 +1,6 @@
+import os
+
+
 APP_TYPES = ['Web App', 'Script', 'Mobile App', 'Chrome Extension']
 ROLES = {
     'product_owner': ['project_description', 'user_stories', 'user_tasks'],
@@ -18,6 +21,8 @@ STEPS = [
     'finished'
 ]
 
+additional_ignore_folders = os.environ.get('IGNORE_FOLDERS', '').split(',')
+
 IGNORE_FOLDERS = [
     '.git',
     '.gpt-pilot',
@@ -29,6 +34,8 @@ IGNORE_FOLDERS = [
     'venv',
     'dist',
     'build',
-]
+    # Used by Rust compiler
+    'target'
+] + [folder for folder in additional_ignore_folders if folder]
 
 PROMPT_DATA_TO_IGNORE = {'directory_tree', 'name'}


### PR DESCRIPTION
When GPT Pilot compiles code to debug, all compilers create lots of files which shouldn't be tracked, and currently IGNORE_FOLDER is hard-coded as constant, this change will allow to include IGNORE_FOLDERS as environment variables, so constant may be kept as it is and shouldn't be extent to infinity with different folder names for different compilers. (As exception I added target folder which created by Rust compiler).