### PR TITLE
Use binary database fields for storing file snapshots

### DIFF
--- a/pilot/database/models/file_snapshot.py
+++ b/pilot/database/models/file_snapshot.py
@@ -1,15 +1,43 @@
-from peewee import ForeignKeyField, TextField
+import logging
+
+from peewee import ForeignKeyField, BlobField
 
 from database.models.components.base_models import BaseModel
 from database.models.development_steps import DevelopmentSteps
 from database.models.app import App
 from database.models.files import File
 
+log = logging.getLogger(__name__)
+
+
+class SmartBlobField(BlobField):
+    """
+    A binary blob field that can also accept/return utf-8 strings.
+
+    This is a temporary workaround for the fact that we're passing either binary
+    or string contents to the database. Once this is cleaned up, we should only
+    accept binary content and explcitily convert from/to strings as needed.
+    """
+
+    def db_value(self, value):
+        if isinstance(value, str):
+            log.warning("FileSnapshot content is a string, expected bytes, working around it.")
+            value = value.encode("utf-8")
+        return super().db_value(value)
+
+    def python_value(self, value):
+        val = bytes(super().python_value(value))
+        try:
+            return val.decode("utf-8")
+        except UnicodeDecodeError:
+            return val
+
+
 class FileSnapshot(BaseModel):
     app = ForeignKeyField(App, on_delete='CASCADE')
     development_step = ForeignKeyField(DevelopmentSteps, backref='files', on_delete='CASCADE')
     file = ForeignKeyField(File, on_delete='CASCADE', null=True)
-    content = TextField()
+    content = SmartBlobField()
 
     class Meta:
         table_name = 'file_snapshot'

--- a/pilot/helpers/files.py
+++ b/pilot/helpers/files.py
@@ -1,15 +1,22 @@
+from typing import Union
+
 from utils.style import color_green
 import os
 
 
-def update_file(path, new_content):
+def update_file(path: str, new_content: Union[str, bytes]):
     # Ensure the directory exists; if not, create it
     dir_name = os.path.dirname(path)
     if not os.path.exists(dir_name):
         os.makedirs(dir_name)
 
+    # TODO: most of the code assumes strings but we may need to
+    # save/update binary files (eg. PNGs) in which case we should
+    # use the binary mode
+    file_mode = "w" if isinstance(new_content, str) else "wb"
+
     # Write content to the file
-    with open(path, 'w') as file:
+    with open(path, file_mode) as file:
         file.write(new_content)
         print(color_green(f"Updated file {path}"))
 

--- a/pilot/test/database/test_file_snapshot.py
+++ b/pilot/test/database/test_file_snapshot.py
@@ -1,0 +1,116 @@
+from base64 import b64decode
+
+from peewee import SqliteDatabase, PostgresqlDatabase
+import pytest
+
+from database.config import (
+    DATABASE_TYPE,
+    DB_NAME,
+    DB_HOST,
+    DB_PORT,
+    DB_USER,
+    DB_PASSWORD,
+)
+from database.database import TABLES
+from database.models.user import User
+from database.models.app import App
+from database.models.file_snapshot import FileSnapshot
+from database.models.files import File
+from database.models.development_steps import DevelopmentSteps
+
+EMPTY_PNG = b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture(autouse=True)
+def database():
+    """
+    Set up a new empty initialized test database.
+
+    In case of SQlite, the database is created in-memory. In case of PostgreSQL,
+    the database should already exist and be empty.
+
+    This fixture will create all the tables and run the test in an isolated transaction.
+    which gets rolled back after the test. The fixture also drops all the tables at the
+    end.
+    """
+    if DATABASE_TYPE == "postgres":
+        if not DB_NAME:
+            raise ValueError(
+                "PostgreSQL database name (DB_NAME) environment variable not set"
+            )
+        db = PostgresqlDatabase(
+            DB_NAME,
+            host=DB_HOST,
+            port=DB_PORT,
+            user=DB_USER,
+            password=DB_PASSWORD,
+        )
+    elif DATABASE_TYPE == "sqlite":
+        db = SqliteDatabase(":memory:")
+    else:
+        raise ValueError(f"Unexpected database type: {DATABASE_TYPE}")
+
+    db.bind(TABLES)
+
+    class PostgresRollback(Exception):
+        """
+        Mock exception to ensure rollback after each test.
+
+        Even though we drop the tables at the end of each test, if the test
+        fails due to database integrity error, we have to roll back the
+        transaction otherwise PostgreSQL will refuse any further work.
+
+        The easiest and safest is to always roll back the transaction.
+        """
+
+        pass
+
+    with db:
+        try:
+            db.create_tables(TABLES)
+            with db.atomic():
+                yield db
+                raise PostgresRollback()
+        except PostgresRollback:
+            pass
+        finally:
+            db.drop_tables(TABLES)
+
+
+def test_create_tables(database):
+    """
+    Test that database tables are created for all the models.
+    """
+    from database.database import TABLES
+
+    with database:
+        tables = database.get_tables()
+        expected_tables = [table._meta.table_name for table in TABLES]
+        assert set(tables) == set(expected_tables)
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_content"),
+    [
+        ("ascii text", "ascii text"),
+        ("non-ascii text: ščćž", "non-ascii text: ščćž"),
+        ("with null byte \0", "with null byte \0"),
+        (EMPTY_PNG, EMPTY_PNG),
+    ],
+)
+def test_file_snapshot(content, expected_content):
+    user = User.create(email="", password="")
+    app = App.create(user=user)
+    step = DevelopmentSteps.create(app=app, llm_response={})
+    file = File.create(app=app, name="test", path="test", full_path="test")
+
+    fs = FileSnapshot.create(
+        app=app,
+        development_step=step,
+        file=file,
+        content=content,
+    )
+    from_db = FileSnapshot.get(id=fs.id)
+    assert from_db.content == expected_content


### PR DESCRIPTION
Since files may be text (utf-8 encoded) or binary, it is better to treat all files as binary and encode/decode when we know we're dealing with text files. SQLite doesn't care, but PostgreSQL does.

Fixes: #41

The rest of the codebase still treats files as (mostly) string with some magical utf8 conversion, which fails with binary files.

This is one step in addressing that, allowing binary files to be correctly stored in PostgreSQL, but we'll gonna be playing whack-a-mole with encoding errors until we update all file save/load to properly distinguish between the two. When trying to reproduce the problem by creating a project and manually injecting some PNG files into the test files I stumbled upon several of those other errors. Fixing those would be too big of a change to try and do in this PR.

## Tests

The reported issue shows an error from PostgreSQL refusing to storing null-byte ('\0') in a text field. I reproduced this error using unit tests (on Linux, though the bug report is from Windows)

<details>
<summary>Click here to expand full log that reproduces the error before the fix</summary>

```
$ DATABASE_TYPE=postgres DB_NAME="test_gpt_pilot" DB_USER="gpt_pilot" DB_PASSWORD="gpt_pilot" DB_HOST="127.0.0.1" PYTHONPATH=$PWD pytest test/database/ -v
============================================================ test session starts =============================================================
platform linux -- Python 3.11.2, pytest-7.4.2, pluggy-1.3.0 -- /home/senko/Projects/Pythagora/gpt-pilot/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/senko/Projects/Pythagora/gpt-pilot
configfile: pytest.ini
collected 5 items                                                                                                                            

test/database/test_file_snapshot.py::test_create_tables PASSED                                                                         [ 20%]
test/database/test_file_snapshot.py::test_file_snapshot[ascii text-ascii text] PASSED                                                  [ 40%]
test/database/test_file_snapshot.py::test_file_snapshot[non-ascii text: \u0161\u010d\u0107\u017e-non-ascii text: \u0161\u010d\u0107\u017e] PASSED [ 60%]
test/database/test_file_snapshot.py::test_file_snapshot[with null byte \x00-with null byte \x00] FAILED                                [ 80%]
test/database/test_file_snapshot.py::test_file_snapshot[\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82-\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82] FAILED [100%]

================================================================== FAILURES ==================================================================
________________________________________ test_file_snapshot[with null byte \x00-with null byte \x00] _________________________________________

content = 'with null byte \x00', expected_content = 'with null byte \x00'

    @pytest.mark.parametrize(
        ("content", "expected_content"),
        [
            ("ascii text", "ascii text"),
            ("non-ascii text: ščćž", "non-ascii text: ščćž"),
            ("with null byte \0", "with null byte \0"),
            (EMPTY_PNG, EMPTY_PNG),
        ],
    )
    def test_file_snapshot(content, expected_content):
        user = User.create(email="", password="")
        app = App.create(user=user)
        step = DevelopmentSteps.create(app=app, llm_response={})
        file = File.create(app=app, name="test", path="test", full_path="test")
    
>       fs = FileSnapshot.create(
            app=app,
            development_step=step,
            file=file,
            content=content,
        )

test/database/test_file_snapshot.py:109: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../.venv/lib/python3.11/site-packages/peewee.py:6577: in create
    inst.save(force_insert=True)
../.venv/lib/python3.11/site-packages/peewee.py:6787: in save
    pk = self.insert(**field_dict).execute()
../.venv/lib/python3.11/site-packages/peewee.py:1966: in inner
    return method(self, database, *args, **kwargs)
../.venv/lib/python3.11/site-packages/peewee.py:2037: in execute
    return self._execute(database)
../.venv/lib/python3.11/site-packages/peewee.py:2842: in _execute
    return super(Insert, self)._execute(database)
../.venv/lib/python3.11/site-packages/peewee.py:2553: in _execute
    cursor = self.execute_returning(database)
../.venv/lib/python3.11/site-packages/peewee.py:2560: in execute_returning
    cursor = database.execute(self)
../.venv/lib/python3.11/site-packages/peewee.py:3254: in execute
    return self.execute_sql(sql, params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <peewee.PostgresqlDatabase object at 0x7fd52ff3c390>
sql = 'INSERT INTO "file_snapshot" ("id", "created_at", "updated_at", "app_id", "development_step_id", "file_id", "content") VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING "file_snapshot"."id"'
params = ['3ccf9fe5edc54129affa0f2a1ccb00ca', datetime.datetime(2023, 10, 28, 12, 5, 0, 129185), datetime.datetime(2023, 10, 28, 12, 5, 0, 129185), '8aa8c667e97c47f3a2c45cb96095b093', 1, 1, ...]
commit = None

    def execute_sql(self, sql, params=None, commit=None):
        if commit is not None:
            __deprecated__('"commit" has been deprecated and is a no-op.')
        logger.debug((sql, params))
        with __exception_wrapper__:
            cursor = self.cursor()
>           cursor.execute(sql, params or ())
E           ValueError: A string literal cannot contain NUL (0x00) characters.

../.venv/lib/python3.11/site-packages/peewee.py:3246: ValueError
_ test_file_snapshot[\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82-\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82] _

content = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82'
expected_content = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82'

    @pytest.mark.parametrize(
        ("content", "expected_content"),
        [
            ("ascii text", "ascii text"),
            ("non-ascii text: ščćž", "non-ascii text: ščćž"),
            ("with null byte \0", "with null byte \0"),
            (EMPTY_PNG, EMPTY_PNG),
        ],
    )
    def test_file_snapshot(content, expected_content):
        user = User.create(email="", password="")
        app = App.create(user=user)
        step = DevelopmentSteps.create(app=app, llm_response={})
        file = File.create(app=app, name="test", path="test", full_path="test")
    
>       fs = FileSnapshot.create(
            app=app,
            development_step=step,
            file=file,
            content=content,
        )

test/database/test_file_snapshot.py:109: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../.venv/lib/python3.11/site-packages/peewee.py:6577: in create
    inst.save(force_insert=True)
../.venv/lib/python3.11/site-packages/peewee.py:6787: in save
    pk = self.insert(**field_dict).execute()
../.venv/lib/python3.11/site-packages/peewee.py:1966: in inner
    return method(self, database, *args, **kwargs)
../.venv/lib/python3.11/site-packages/peewee.py:2037: in execute
    return self._execute(database)
../.venv/lib/python3.11/site-packages/peewee.py:2842: in _execute
    return super(Insert, self)._execute(database)
../.venv/lib/python3.11/site-packages/peewee.py:2553: in _execute
    cursor = self.execute_returning(database)
../.venv/lib/python3.11/site-packages/peewee.py:2560: in execute_returning
    cursor = database.execute(self)
../.venv/lib/python3.11/site-packages/peewee.py:3253: in execute
    sql, params = ctx.sql(query).query()
../.venv/lib/python3.11/site-packages/peewee.py:628: in sql
    return obj.__sql__(self)
../.venv/lib/python3.11/site-packages/peewee.py:2819: in __sql__
    self._simple_insert(ctx)
../.venv/lib/python3.11/site-packages/peewee.py:2669: in _simple_insert
    return self._generate_insert((self._insert,), ctx)
../.venv/lib/python3.11/site-packages/peewee.py:2791: in _generate_insert
    return ctx.sql(CommaNodeList(all_values))
../.venv/lib/python3.11/site-packages/peewee.py:628: in sql
    return obj.__sql__(self)
../.venv/lib/python3.11/site-packages/peewee.py:1832: in __sql__
    ctx.sql(self.nodes[n_nodes - 1])
../.venv/lib/python3.11/site-packages/peewee.py:628: in sql
    return obj.__sql__(self)
../.venv/lib/python3.11/site-packages/peewee.py:1832: in __sql__
    ctx.sql(self.nodes[n_nodes - 1])
../.venv/lib/python3.11/site-packages/peewee.py:628: in sql
    return obj.__sql__(self)
../.venv/lib/python3.11/site-packages/peewee.py:1430: in __sql__
    return ctx.value(self.value, self.converter)
../.venv/lib/python3.11/site-packages/peewee.py:640: in value
    value = converter(value)
../.venv/lib/python3.11/site-packages/peewee.py:4744: in db_value
    return value if value is None else self.adapt(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <TextField: FileSnapshot.content>
value = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82'

    def adapt(self, value):
        if isinstance(value, text_type):
            return value
        elif isinstance(value, bytes_type):
>           return value.decode('utf-8')
E           UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte

../.venv/lib/python3.11/site-packages/peewee.py:4899: UnicodeDecodeError
========================================================== short test summary info ===========================================================
FAILED test/database/test_file_snapshot.py::test_file_snapshot[with null byte \x00-with null byte \x00] - ValueError: A string literal cannot contain NUL (0x00) characters.
FAILED test/database/test_file_snapshot.py::test_file_snapshot[\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82-\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82] - UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
======================================================== 2 failed, 3 passed in 1.93s =========================================================
```
</details>

After applying the fix:

<details>
<summary>PostgreSQL test run</summary>

```
$ DATABASE_TYPE=postgres DB_NAME="test_gpt_pilot" DB_USER="gpt_pilot" DB_PASSWORD="gpt_pilot" DB_HOST="127.0.0.1" PYTHONPATH=$PWD pytest test/database/ -v
============================================================ test session starts =============================================================
platform linux -- Python 3.11.2, pytest-7.4.2, pluggy-1.3.0 -- /home/senko/Projects/Pythagora/gpt-pilot/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/senko/Projects/Pythagora/gpt-pilot
configfile: pytest.ini
collected 5 items                                                                                                                            

test/database/test_file_snapshot.py::test_create_tables PASSED                                                                         [ 20%]
test/database/test_file_snapshot.py::test_file_snapshot[ascii text-ascii text] PASSED                                                  [ 40%]
test/database/test_file_snapshot.py::test_file_snapshot[non-ascii text: \u0161\u010d\u0107\u017e-non-ascii text: \u0161\u010d\u0107\u017e] PASSED [ 60%]
test/database/test_file_snapshot.py::test_file_snapshot[with null byte \x00-with null byte \x00] PASSED                                [ 80%]
test/database/test_file_snapshot.py::test_file_snapshot[\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82-\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82] PASSED [100%]

============================================================= 5 passed in 1.80s ==============================================================
```
</details>

<details>
<summary>SQLite test run</summary>

```
$ DATABASE_TYPE=sqlite PYTHONPATH=$PWD pytest test/database/ -v
============================================================ test session starts =============================================================
platform linux -- Python 3.11.2, pytest-7.4.2, pluggy-1.3.0 -- /home/senko/Projects/Pythagora/gpt-pilot/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/senko/Projects/Pythagora/gpt-pilot
configfile: pytest.ini
collected 5 items                                                                                                                            

test/database/test_file_snapshot.py::test_create_tables PASSED                                                                         [ 20%]
test/database/test_file_snapshot.py::test_file_snapshot[ascii text-ascii text] PASSED                                                  [ 40%]
test/database/test_file_snapshot.py::test_file_snapshot[non-ascii text: \u0161\u010d\u0107\u017e-non-ascii text: \u0161\u010d\u0107\u017e] PASSED [ 60%]
test/database/test_file_snapshot.py::test_file_snapshot[with null byte \x00-with null byte \x00] PASSED                                [ 80%]
test/database/test_file_snapshot.py::test_file_snapshot[\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82-\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\xdacd`\xf8_\x0f\x00\x02\x87\x01\x80\xebG\xba\x92\x00\x00\x00\x00IEND\xaeB`\x82] PASSED [100%]

============================================================= 5 passed in 0.09s ==============================================================
```
</details>


