### PR TITLE
expand user home folder when creating .gpt-pilot directory

### DIFF
--- a/pilot/utils/dot_gpt_pilot.py
+++ b/pilot/utils/dot_gpt_pilot.py
@@ -25,7 +25,7 @@ class DotGptPilot:
     def with_root_path(self, root_path: str, create=True):
         if not USE_GPTPILOT_FOLDER:
             return
-        dot_gpt_pilot_path = os.path.join(root_path, '.gpt-pilot')
+        dot_gpt_pilot_path = os.path.expanduser(os.path.join(root_path, '.gpt-pilot'))
         self.dot_gpt_pilot_path = dot_gpt_pilot_path
 
         # Create the `.gpt-pilot` directory if required.


### PR DESCRIPTION
If `USE_GPTPILOT_FOLDER` is set, a bogus `pilot/~` directory will be created. This is because `DotGptPilot.with_root_path()` doesn't expand `~` into full path, so it's appended to the current working directory.

It's annoying and possibly dangerous if people see this directory and attempt to remove it with `rm -rf ~`, which will erase their home directory instead.

This fixes it by making sure the path is expanded. 

As an aside, I'm not sure if we should create `~/.gpt-pilot` at all, since that one is not used. Instead, we create a directory within each project as soon as the project is created, and use that one. However, this seems to have been intentional:

https://github.com/Pythagora-io/gpt-pilot/blob/a441c96cd66292316617d568ee833cccc0a3f83d/pilot/utils/dot_gpt_pilot.py#L33

## Test

Before the fix:

```
$ ls -ld $PWD/~
ls: cannot access '/home/senko/Projects/Pythagora/gpt-pilot/pilot/~': No such file or directory

$ python main.py
------------------ STARTING NEW PROJECT ----------------------
If you wish to continue with this project in future run:
python main.py app_id=24edabc2-4982-434d-bfde-bf5466840ff2
--------------------------------------------------------------
? What is the project name?
^C
[...stack trace omitted for clarity...]
KeyboardInterrupt

$ ls -ld $PWD/~
drwxr-xr-x 3 senko senko 4096 Oct 31 11:40 /home/senko/Projects/Pythagora/gpt-pilot/pilot/~
```

After the fix:

```
$ ls -ld $PWD/~
ls: cannot access '/home/senko/Projects/Pythagora/gpt-pilot/pilot/~': No such file or directory

$ python main.py
------------------ STARTING NEW PROJECT ----------------------
If you wish to continue with this project in future run:
python main.py app_id=048fe17f-fa6d-4695-9359-92f96896b98a
--------------------------------------------------------------
? What is the project name?
^C
[...stack trace omitted for clarity...]
KeyboardInterrupt

$ ls -ld $PWD/~
ls: cannot access '/home/senko/Projects/Pythagora/gpt-pilot/pilot/~': No such file or directory
```