### PR TITLE
fix reading stdout and stderr when running commands

### DIFF
--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -10,7 +10,8 @@ AZURE_ENDPOINT=
 OPENROUTER_API_KEY=
 
 # In case of Azure/OpenRouter endpoint, change this to your deployed model name
-MODEL_NAME=gpt-4
+MODEL_NAME=gpt-4-1106-preview
+# MODEL_NAME=gpt-4
 # MODEL_NAME=openai/gpt-3.5-turbo-16k
 MAX_TOKENS=8192
 

--- a/pilot/helpers/cli.py
+++ b/pilot/helpers/cli.py
@@ -116,9 +116,9 @@ def read_queue_line(q, stdout=True):
     try:
         line = q.get_nowait()
     except queue.Empty:
-        line = None
+        return ''
 
-    if line and stdout:
+    if stdout:
         print(color_green('CLI OUTPUT:') + line, end='')
         logger.info('CLI OUTPUT: ' + line)
         # if success_message is not None and success_message in line:
@@ -126,11 +126,11 @@ def read_queue_line(q, stdout=True):
         #     # break # TODO background_command - this is if we want to leave command running in background but sometimes processes keep hanging and terminal gets bugged, also if we do that we have to change user messages to make it clear that there is command running in background
         #     raise CommandFinishedEarly()
 
-    if line and not stdout:  # stderr
+    if not stdout:  # stderr
         print(color_red('CLI ERROR:') + line, end='')
         logger.error('CLI ERROR: ' + line)
 
-    return line if line else ''
+    return line
 
 
 def read_remaining_queue(q, stdout=True):

--- a/pilot/helpers/test_cli.py
+++ b/pilot/helpers/test_cli.py
@@ -34,10 +34,7 @@ def test_execute_command_timeout_exit_code(mock_terminate_process, mock_run, moc
     assert cli_response is not None
     assert llm_response == 'took longer than 100.0ms so I killed it'
     assert exit_code is not None
-    mock_terminate_process.assert_has_calls([
-        call(1234),
-        call(1234),
-    ])
+    mock_terminate_process.assert_called_once_with(1234)
 
 
 def mock_run_command(command, path, q, q_stderr):

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -291,7 +291,7 @@ def stream_gpt_completion(data, req_type, project):
             lines_printed += count_lines_based_on_width(buffer, terminal_width)
         logger.debug(f'lines printed: {lines_printed} - {terminal_width}')
 
-        # delete_last_n_lines(lines_printed)
+        # delete_last_n_lines(lines_printed)  # TODO fix and test count_lines_based_on_width()
         return result_data
 
     # spinner = spinner_start(yellow("Waiting for OpenAI API response..."))

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -291,7 +291,7 @@ def stream_gpt_completion(data, req_type, project):
             lines_printed += count_lines_based_on_width(buffer, terminal_width)
         logger.debug(f'lines printed: {lines_printed} - {terminal_width}')
 
-        delete_last_n_lines(lines_printed)
+        # delete_last_n_lines(lines_printed)
         return result_data
 
     # spinner = spinner_start(yellow("Waiting for OpenAI API response..."))


### PR DESCRIPTION
This fixes a problem where GPT-Pilot doesn't always capture full output.

Example, output captured:

```
Got incorrect CLI response:
stderr:
---


---
stdout:
---

> h4-app@1.0.0 build
> nexe index.js -t windows-x64-14.15.4 && nexe index.js -t mac-x64-14.15.4 && nexe index.js -t linux-x64-14.15.4

---
```

While the actual stderr is:

```
> h4-app@1.0.0 build
> nexe index.js -t windows-x64-14.15.4 && nexe index.js -t mac-x64-14.15.4 && nexe index.js -t linux-x64-14.15.4


Error: Entry file "" not found!

See nexe -h for usage..
```

The `Entry file "" not found` message is an important hint but GPT Pilot never sees it for some reason, and then it needs to debug from scratch.

This PR fixes the problem.