### PR TITLE
Run GitHub CI actions on development branch, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - development
   pull_request:
     branches:
       - main
+      - development
 
 jobs:
   Docker:


### PR DESCRIPTION
This enables running GitHub actions on the `development` branch, so we can continue to have these checks on PRs that are made against that branch.
