### PR TITLE
Improve IPC performance

### DIFF
--- a/pilot/helpers/ipc.py
+++ b/pilot/helpers/ipc.py
@@ -37,9 +37,6 @@ class IPCClient:
 
     def send(self, data):
         serialized_data = json.dumps(data, default=json_serial)
-        print(serialized_data, type='local')
-
         data_length = len(serialized_data)
         self.client.sendall(data_length.to_bytes(4, byteorder='big'))
         self.client.sendall(serialized_data.encode('utf-8'))
-        time.sleep(0.1)


### PR DESCRIPTION
When using IPC, GPT-Pilot unneccessarily waits and prints the data to stdout. This slows it down with no good reason.

Before the fix:

https://github.com/Pythagora-io/gpt-pilot/assets/3362/5773aba3-a005-428b-a1d3-4039b6fa213f

After the fix:

https://github.com/Pythagora-io/gpt-pilot/assets/3362/7cb06b28-11cc-45f6-a1ec-de0e7fca65a0




