### PR TITLE
Various fixes

### DIFF
--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -212,14 +212,13 @@ class AgentConvo:
         return s
 
     def replace_file_content(self, message, file_path, new_content):
-        escaped_file_path = re.escape(file_path)
-
-        pattern = rf'\*\*{escaped_file_path}\*\*:\n```\n(.*?)\n```'
+        pattern = rf'\*\*{re.escape(file_path)}\*\*:\n```\n(.*?)\n```'
 
         # Escape special characters in new_content for the sake of regex replacement
         new_content_escaped = self.escape_specials(new_content)
+        file_path_escaped = self.escape_specials(file_path)
 
-        new_section_content = f'**{file_path}**\n```\n{new_content_escaped}\n```'
+        new_section_content = f'**{file_path_escaped}**\n```\n{new_content_escaped}\n```'
 
         updated_message, num_replacements = re.subn(pattern, new_section_content, message, flags=re.DOTALL)
 

--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -121,7 +121,7 @@ class Project:
                     print('yes/no', type='button')
                     should_overwrite_files = styled_text(
                         self,
-                        f'Do you want to overwrite the dev step {self.args["skip_until_dev_step"]} code with system changes? Type y/n',
+                        "Can I overwrite any changes that you might have made to the project since last running GPT Pilot (y/n)?",
                         ignore_user_input_count=True
                     )
 

--- a/pilot/logger/logger.py
+++ b/pilot/logger/logger.py
@@ -8,7 +8,11 @@ def setup_logger():
     log_format = "%(asctime)s [%(filename)s:%(lineno)s - %(funcName)20s() ] %(levelname)s: %(message)s"
 
     # Create a log handler for file output
-    file_handler = logging.FileHandler(filename=os.path.join(os.path.dirname(__file__), 'debug.log'), mode='w')
+    file_handler = logging.FileHandler(
+        filename=os.path.join(os.path.dirname(__file__), 'debug.log'),
+        mode='w',
+        encoding='utf-8',
+    )
 
     # Apply the custom format to the handler
     formatter = logging.Formatter(log_format)


### PR DESCRIPTION
* fix Windows file path escaping in file modifications
* be explicit about the log code page (also helps for Windows)
* improve file overwrite message

