### PR TITLE
Create HowTo.md for Transferring GPT Pilot Projects Between Devices #430 

### DIFF
--- a/docs/HowTo.md
+++ b/docs/HowTo.md
@@ -1,0 +1,39 @@
+
+# Instructions for Adding a GPT Pilot Project to a New Device
+
+## Prerequisites
+
+- GPT Pilot is installed and set up on both devices.
+
+- Make note of the installation folders on each device.
+
+## On Original Device
+
+- Locate the `gpt-pilot` folder inside the GPT Pilot installation folder.
+
+- Inside is a `pilot` folder, containing the `gpt-pilot` database file. 
+
+- Also locate the workspace folder for the project.
+
+## On Target Device 
+
+- Make sure GPT Pilot extension is not running.
+
+## Copy Files
+
+- Copy the database file and workspace folder to the same locations on the target device.
+
+## Using Project on New Device
+
+- Launch GPT Pilot extension.
+
+- The copied project should now be available.
+
+## Considerations
+
+- Make sure to copy the full database and workspace folder.
+
+- Database path may differ on each device.
+
+- Workspace can be anywhere but should match original structure.
+


### PR DESCRIPTION
I have created a comprehensive HowTo.md file (#430) that provides step-by-step instructions on transferring a GPT Pilot project from one device to another. This guide covers prerequisites, file locations, and considerations to ensure a smooth transition. Please review and consider merging this contribution to enhance the user experience for GPT Pilot users seeking to seamlessly move their projects between devices.

## Changes Made

- Added detailed instructions in the HowTo.md file.
- Addressed considerations for copying the full database and workspace folder.
- Emphasized the importance of matching the original workspace structure.

## Checklist

- [x] The HowTo.md file has been added with the relevant content.
- [x] Instructions are clear and concise.
- [x] Considerations for a successful transfer are highlighted.
- [x] The HowTo.md file has been tested for accuracy.

Please review and merge at your earliest convenience.
