### PR TITLE
IPC: read bigger chunks of text from the extension

### DIFF
--- a/pilot/helpers/ipc.py
+++ b/pilot/helpers/ipc.py
@@ -28,7 +28,7 @@ class IPCClient:
             return
 
         while True:
-            data = self.client.recv(4096)
+            data = self.client.recv(65536)
             message = json.loads(data)
 
             if message['type'] == 'response':


### PR DESCRIPTION
GPT Pilot reads only up to 4096 bytes of message from the VSCode extension. This is a problem if the user pastes big chunk of text, such as when describing their project at the start, or when pasting errors during debugging.

The fix is simple - allow larger reads.

Before:

![Screenshot from 2024-01-05 19-27-04](https://github.com/Pythagora-io/gpt-pilot/assets/3362/e17558b1-4222-40ae-a202-e1196adeeb98)

After:

![Screenshot from 2024-01-05 19-28-21](https://github.com/Pythagora-io/gpt-pilot/assets/3362/a0e29104-72b1-4a3e-8434-0fabe3467ac9)

Fixes: #495, #477, 
