### PR TITLE
Allow user to enter input/help while debugging a problem

### DIFF
--- a/pilot/helpers/Debugger.py
+++ b/pilot/helpers/Debugger.py
@@ -47,7 +47,7 @@ class Debugger:
 
             if ask_before_debug or i > 0:
                 print('yes/no', type='button')
-                answer = ask_user(self.agent.project, 'Can I start debugging this issue?', require_some_input=False)
+                answer = ask_user(self.agent.project, 'Can I start debugging this issue [Y/n/error details]?', require_some_input=False)
                 if answer.lower() in NEGATIVE_ANSWERS:
                     return True
                 if answer and answer.lower() not in AFFIRMATIVE_ANSWERS:

--- a/pilot/prompts/dev_ops/debug.prompt
+++ b/pilot/prompts/dev_ops/debug.prompt
@@ -3,12 +3,11 @@ You wanted me to check this - `{{ issue_description }}` but there was a problem
 {%- else -%}
 Ok, we need to debug this issue
 {%- endif -%}
-{% if command %} and we need to be able to execute `{{ command }}` successfully. {% else %}.
-Here is a brief explanation of what's happening:
+{% if command %} and we need to be able to execute `{{ command }}` successfully. {% endif %}.
+{% if user_input %}Here is a brief explanation of what's happening:
 ```
 {{ user_input }}
-```
-{% endif -%}
+```{% endif -%}
 {{ context }}
 I want you to create a list of steps that are needed to debug this issue.
 


### PR DESCRIPTION
Allows user to specify what's wrong when starting the debugging loop:

"Can I debug" prompt:

![Screenshot from 2024-01-10 10-46-30](https://github.com/Pythagora-io/gpt-pilot/assets/3362/cc472eb0-056e-4f3a-9bfd-80296dd924b9)

User's message sent to gpt-pilot core:

![Screenshot from 2024-01-10 10-46-46](https://github.com/Pythagora-io/gpt-pilot/assets/3362/6550730d-a75a-4d0f-a44d-a986aa71e18e)

Contents of the message sent (from `debug.prompt`, note that the previous message has the full stderr log):

```
Ok, we need to debug this issue and we need to be able to execute `npm install express dotenv` successfully. .
Here is a brief explanation of what's happening:
\```
the package.json file is corrupted and needs to be fixed
\```
The project directory tree looks like:

/: package.json


I want you to create a list of steps that are needed to debug this issue.

A step can be either a `command` or `code_change`.

`command` step will run a command on the machine and will return the CLI output to you so you can see what to do next. Note that the command will be run on a Linux machine.

`code_change` step will change the code and you need to thoroughly describe what needs to be implemented. I will implement the requested changes and let you know.

Also, make sure that at least the last step has `check_if_fixed` set to TRUE.

**IMPORTANT**
When you think about in which file should the new code go to, always try to make files as small as possible and put code in more smaller files rather than in one big file. Whenever a file becomes too large (more than 50 lines of code) split it into smaller files.
```

Fixes: #505 
