### PR TITLE
Diagnostics: ignore stack frames from 3rd party packages

### DIFF
--- a/pilot/utils/telemetry.py
+++ b/pilot/utils/telemetry.py
@@ -234,7 +234,8 @@ class Telemetry:
                 "file": file_path,
                 "line": tb.tb_lineno
             }
-            frames.append(frame_info)
+            if not file_path.startswith('pilot-env'):
+                frames.append(frame_info)
             tb = tb.tb_next
 
         frames.reverse()


### PR DESCRIPTION
When gathering diagnostics data, ignore frames that aren't from gpt-pilot.