### PR TITLE
make Telemetry.record_crash() more resilient

### DIFF
--- a/pilot/main.py
+++ b/pilot/main.py
@@ -91,12 +91,11 @@ if __name__ == "__main__":
             run_exit_fn = False
 
     except Exception as err:
-        telemetry.record_crash(err)
         print(color_red('---------- GPT PILOT EXITING WITH ERROR ----------'))
         traceback.print_exc()
         print(color_red('--------------------------------------------------'))
         ask_feedback = False
-        telemetry.set("end_result", "failure")
+        telemetry.record_crash(err)
 
     finally:
         if run_exit_fn:

--- a/pilot/test/utils/test_telemetry.py
+++ b/pilot/test/utils/test_telemetry.py
@@ -336,8 +336,27 @@ def test_record_crash(mock_settings):
     except Exception as err:
         telemetry.record_crash(err)
 
+    assert telemetry.data["end_result"] == "failure"
     diag = telemetry.data["crash_diagnostics"]
     assert diag["exception_class"] == "ValueError"
     assert diag["exception_message"] == "test error"
     assert diag["frames"][0]["file"] == "pilot/test/utils/test_telemetry.py"
     assert "ValueError: test error" in diag["stack_trace"]
+
+
+@patch("utils.telemetry.settings")
+def test_record_crash_crashes(mock_settings):
+    mock_settings.telemetry = {
+        "id": "test-id",
+        "endpoint": "test-endpoint",
+        "enabled": True,
+    }
+
+    telemetry = Telemetry()
+    telemetry.record_crash(None)
+
+    assert telemetry.data["end_result"] == "failure"
+    diag = telemetry.data["crash_diagnostics"]
+    assert diag["exception_class"] == "NoneType"
+    assert diag["exception_message"] == "None"
+    assert diag["frames"] == []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 requirements = open("requirements.txt").readlines()
 


### PR DESCRIPTION
This moves telemetry crash recorder to the last step in the exception handling (so if it crashes, we still have useful info).

Also makes the Telemetry crash reporter code a bit more resilient.
