### PR TITLE
Ignore files based on name(glob), size and whether they're binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ After you have Python and (optionally) PostgreSQL installed, follow these steps:
    - LLM Provider (OpenAI/Azure/Openrouter)
    - Your API key
    - database settings: SQLite/PostgreSQL (to change from SQLite to PostgreSQL, just set `DATABASE_TYPE=postgres`)
-   - optionally set IGNORE_FOLDERS for the folders which shouldn't be tracked by GPT Pilot in workspace, useful to ignore folders created by compilers (i.e. `IGNORE_FOLDERS=folder1,folder2,folder3`)
+   - optionally set IGNORE_PATHS for the folders which shouldn't be tracked by GPT Pilot in workspace, useful to ignore folders created by compilers (i.e. `IGNORE_PATHS=folder1,folder2,folder3`)
 9. `python db_init.py` (initialize the database)
 10. `python main.py` (start GPT Pilot)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
             - DB_USER=pilot
             - DB_PASSWORD=pilot
             # Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)
-            # IGNORE_FOLDERS=folder1,folder2
+            # IGNORE_PATHS=folder1,folder2
         volumes:
             - ~/gpt-pilot-workspace:/usr/src/app/workspace
         build:

--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -28,3 +28,6 @@ DB_USER=
 DB_PASSWORD=
 
 USE_GPTPILOT_FOLDER=true
+
+# Load database imported from another location/system - EXPERIMENTAL
+# AUTOFIX_FILE_PATHS=false

--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -16,7 +16,7 @@ MODEL_NAME=gpt-4-1106-preview
 MAX_TOKENS=8192
 
 # Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)
-# IGNORE_FOLDERS=folder1,folder2
+# IGNORE_PATHS=folder1,folder2
 
 # Database
 # DATABASE_TYPE=postgres

--- a/pilot/const/common.py
+++ b/pilot/const/common.py
@@ -21,10 +21,7 @@ STEPS = [
     'finished'
 ]
 
-additional_ignore_folders = os.environ.get('IGNORE_FOLDERS', '').split(',')
-
-# TODO: rename to IGNORE_PATHS as it also contains files
-IGNORE_FOLDERS = [
+DEFAULT_IGNORE_PATHS = [
     '.git',
     '.gpt-pilot',
     '.idea',
@@ -36,7 +33,16 @@ IGNORE_FOLDERS = [
     'venv',
     'dist',
     'build',
-    'target'
-] + [folder for folder in additional_ignore_folders if folder]
-
+    'target',
+    "*.min.js",
+    "*.min.css",
+    "*.svg",
+    "*.csv",
+]
+IGNORE_PATHS = DEFAULT_IGNORE_PATHS + [
+    folder for folder
+    in os.environ.get('IGNORE_PATHS', '').split(',')
+    if folder
+]
+IGNORE_SIZE_THRESHOLD = 102400  # 100K+ files are ignored by default
 PROMPT_DATA_TO_IGNORE = {'directory_tree', 'name'}

--- a/pilot/database/models/files.py
+++ b/pilot/database/models/files.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+from os.path import commonprefix, join, sep
 from peewee import AutoField, CharField, TextField, ForeignKeyField
 
 from database.models.components.base_models import BaseModel
@@ -16,3 +18,36 @@ class File(BaseModel):
         indexes = (
             (('app', 'name', 'path'), True),
         )
+
+    @staticmethod
+    def update_paths():
+        workspace_dir = Path(__file__).parent.parent.parent.parent / "workspace"
+        if not workspace_dir.exists():
+            # This should only happen on first run
+            return
+
+        paths = [file.full_path for file in File.select(File.full_path).distinct()]
+        if not paths:
+            # No paths in the database, so nothing to fix
+            return
+
+        common_prefix = commonprefix(paths)
+        if commonprefix([common_prefix, str(workspace_dir)]) == str(workspace_dir):
+            # Paths are up to date, nothing to fix
+            return
+
+        common_sep = "\\" if ":\\" in common_prefix else "/"
+        common_parts = common_prefix.split(common_sep)
+        try:
+            workspace_index = common_parts.index("workspace")
+        except ValueError:
+            # There's something strange going on, better not touch anything
+            return
+        old_prefix = common_sep.join(common_parts[:workspace_index + 1])
+
+        print(f"Updating file paths from {old_prefix} to {workspace_dir}")
+        for file in File.select().where(File.full_path.startswith(old_prefix)):
+            parts = file.full_path.split(common_sep)
+            new_path = str(workspace_dir) + sep + sep.join(parts[workspace_index + 1:])
+            file.full_path = new_path
+            file.save()

--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -80,6 +80,9 @@ class Project:
         self.development_plan = development_plan
         self.dot_pilot_gpt = DotGptPilot(log_chat_completions=enable_dot_pilot_gpt)
 
+        if os.getenv("AUTOFIX_FILE_PATHS", "").lower() in ["true", "1", "yes"]:
+            File.update_paths()
+
     def set_root_path(self, root_path: str):
         self.root_path = root_path
         self.dot_pilot_gpt.with_root_path(root_path)

--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -8,7 +8,7 @@ import peewee
 
 from const.messages import CHECK_AND_CONTINUE, AFFIRMATIVE_ANSWERS, NEGATIVE_ANSWERS
 from utils.style import color_yellow_bold, color_cyan, color_white_bold, color_green
-from const.common import IGNORE_FOLDERS, STEPS
+from const.common import STEPS
 from database.database import delete_unconnected_steps_from, delete_all_app_development_data, update_app_status
 from const.ipc import MESSAGE_TYPE
 from prompts.prompts import ask_user
@@ -28,6 +28,7 @@ from database.models.files import File
 from logger.logger import logger
 from utils.dot_gpt_pilot import DotGptPilot
 from utils.llm_connection import test_api_access
+from utils.ignore import IgnoreMatcher
 
 from utils.telemetry import telemetry
 
@@ -176,12 +177,7 @@ class Project:
         Returns:
             dict: The directory tree.
         """
-        # files = {}
-        # if with_descriptions and False:
-        #     files = File.select().where(File.app_id == self.args['app_id'])
-        #     files = {snapshot.name: snapshot for snapshot in files}
-        # return build_directory_tree_with_descriptions(self.root_path, ignore=IGNORE_FOLDERS, files=files, add_descriptions=False)
-        return build_directory_tree(self.root_path, ignore=IGNORE_FOLDERS)
+        return build_directory_tree(self.root_path)
 
     def get_test_directory_tree(self):
         """
@@ -191,7 +187,7 @@ class Project:
             dict: The directory tree of tests.
         """
         # TODO remove hardcoded path
-        return build_directory_tree(self.root_path + '/tests', ignore=IGNORE_FOLDERS)
+        return build_directory_tree(self.root_path + '/tests')
 
     def get_all_coded_files(self):
         """
@@ -209,18 +205,7 @@ class Project:
                 )
             )
 
-        files = self.get_files([file.path + '/' + file.name for file in files])
-
-        # Don't send contents of binary files
-        for file in files:
-            if not isinstance(file["content"], str):
-                file["content"] = f"<<binary file, {len(file['content'])} bytes>>"
-
-        # TODO temoprary fix to eliminate files that are not in the project
-        files = [file for file in files if file['content'] != '']
-        # TODO END
-
-        return files
+        return self.get_files([file.path + '/' + file.name for file in files])
 
     def get_files(self, files):
         """
@@ -232,6 +217,7 @@ class Project:
         Returns:
             list: A list of files with content.
         """
+        matcher = IgnoreMatcher(root_path=self.root_path)
         files_with_content = []
         for file_path in files:
             try:
@@ -239,9 +225,12 @@ class Project:
                 _, full_path = self.get_full_file_path(file_path, file_path)
                 file_data = get_file_contents(full_path, self.root_path)
             except ValueError:
+                full_path = None
                 file_data = {"path": file_path, "name": os.path.basename(file_path), "content": ''}
 
-            files_with_content.append(file_data)
+            if full_path and file_data["content"] != "" and not matcher.ignore(full_path):
+                files_with_content.append(file_data)
+
         return files_with_content
 
     def find_input_required_lines(self, file_content):
@@ -395,7 +384,7 @@ class Project:
 
 
     def save_files_snapshot(self, development_step_id):
-        files = get_directory_contents(self.root_path, ignore=IGNORE_FOLDERS)
+        files = get_directory_contents(self.root_path)
         development_step, created = DevelopmentSteps.get_or_create(id=development_step_id)
 
         total_files = 0
@@ -431,7 +420,7 @@ class Project:
         development_step = DevelopmentSteps.get(DevelopmentSteps.id == development_step_id)
         file_snapshots = FileSnapshot.select().where(FileSnapshot.development_step == development_step)
 
-        clear_directory(self.root_path, IGNORE_FOLDERS + self.files)
+        clear_directory(self.root_path, ignore=self.files)
         for file_snapshot in file_snapshots:
             update_file(file_snapshot.file.full_path, file_snapshot.content, project=self)
             if file_snapshot.file.full_path not in self.files:

--- a/pilot/helpers/test_Project.py
+++ b/pilot/helpers/test_Project.py
@@ -363,7 +363,7 @@ class TestProjectFileLists:
             'user_review_goal': 'Test User Review Goal',
         }]
 
-        # with directories including common.IGNORE_FOLDERS
+        # with directories including common.IGNORE_PATHS
         src = os.path.join(project.root_path, 'src')
         foo = os.path.join(project.root_path, 'src/foo')
         files_no_folders = os.path.join(foo, 'files_no_folders')

--- a/pilot/test/helpers/test_files.py
+++ b/pilot/test/helpers/test_files.py
@@ -147,14 +147,13 @@ def test_get_directory_contents_live():
     assert isinstance(this_file["content"], str)
     assert "test_get_directory_contents_live()" in this_file["content"]
 
-    # Check that the Python cache was loaded as a binary file
-    print("FILES", [(f["path"], f["name"]) for f in files])
-    pycache_file = [
+    # Check that the binary file was ignored
+    image_files = [
         f
         for f in files
         if f["path"] == "helpers" and f["name"] == "testlogo.png"
-    ][0]
-    assert isinstance(pycache_file["content"], bytes)
+    ]
+    assert image_files == []
 
     # Check that the ignore list works
     assert all(file["name"] != "__init__.py" for file in files)

--- a/pilot/test/utils/test_ignore.py
+++ b/pilot/test/utils/test_ignore.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+import pytest
+from tempfile import TemporaryDirectory
+
+from utils.ignore import IgnoreMatcher
+from os.path import sep, join, dirname
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (".git", True),
+        (".gpt-pilot", True),
+        (".idea", True),
+        (".vscode", True),
+        (".DS_Store", True),
+        (join("subdirectory", ".DS_Store"), True),
+        ("__pycache__", True),
+        (join("subdirectory", "__pycache__"), True),
+        ("node_modules", True),
+        (join("subdirectory", "node_modules"), True),
+        ("package-lock.json", True),
+        ("venv", True),
+        ("dist", True),
+        ("build", True),
+        ("target", True),
+        (".gitignore", False),
+        ("server.js", False),
+        (join(dirname(__file__), "node_modules"), True),
+        (join(dirname(__file__), "subdirectory", "node_modules"), True),
+    ]
+)
+def test_default_ignore(path, expected):
+    matcher = IgnoreMatcher(root_path=dirname(__file__))
+    assert matcher.ignore(path) == expected
+
+
+@pytest.mark.parametrize(
+    ("ignore", "path", "expected"),
+    [
+        ("*.py[co]", "test.pyc", True),
+        ("*.py[co]", "subdir/test.pyo", True),
+        ("*.py[co]", "test.py", False),
+        ("*.min.js", f"public{sep}js{sep}script.min.js", True),
+        ("*.min.js", f"public{sep}js{sep}min.js", False),
+    ]
+)
+def test_additional_ignore(ignore, path, expected):
+    matcher = IgnoreMatcher([ignore])
+    assert matcher.ignore(path) == expected
+
+
+@pytest.mark.parametrize(
+    ("ignore", "path", "expected"),
+    [
+        ("jquery.js", "jquery.js", True),
+        ("jquery.js", f"otherdir{sep}jquery.js", True),
+        ("jquery.js", f"{sep}test{sep}jquery.js", True),
+    ]
+)
+def test_full_path(ignore, path, expected):
+    matcher = IgnoreMatcher([ignore], root_path=f"{sep}test")
+    assert matcher.ignore(path) == expected
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (1024*1024, True),  # 1MB
+        (102400, False),    # 100KB
+    ]
+)
+@patch("utils.ignore.os.path.isfile")
+@patch("utils.ignore.os.path.getsize")
+def test_ignore_large_files(mock_getsize, mock_isfile, size, expected):
+    mock_isfile.return_value = True
+    mock_getsize.return_value = size
+    matcher = IgnoreMatcher(root_path=f"{sep}test")
+
+    with patch.object(matcher, "is_binary", return_value=False):
+        assert matcher.ignore("fakefile.txt") is expected
+
+    mock_isfile.assert_called_once()
+    mock_getsize.assert_called_once_with(f"{sep}test{sep}fakefile.txt")
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (("hello world ŠĐŽČĆ").encode("utf-8"), False),  # text
+        (b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52", True), # image
+    ]
+)
+def test_ignore_binary_files(content, expected):
+    with TemporaryDirectory() as tmpdir:
+        path = join(tmpdir, "testfile.txt")
+        with open(path, "wb") as fp:
+            fp.write(content)
+
+        matcher = IgnoreMatcher(root_path=tmpdir)
+        # Check both relative and absolute paths
+        assert matcher.ignore("testfile.txt") is expected
+        assert matcher.ignore(path) is expected

--- a/pilot/utils/ignore.py
+++ b/pilot/utils/ignore.py
@@ -1,0 +1,97 @@
+from fnmatch import fnmatch
+import os.path
+from typing import Optional
+
+from const.common import IGNORE_PATHS, IGNORE_SIZE_THRESHOLD
+
+
+class IgnoreMatcher:
+    def __init__(self,
+        ignore_paths: Optional[list[str]] = None,
+        *,
+        root_path: Optional[None] = None,
+        ignore_binaries: bool = True,
+        ignore_large_files: bool = True,
+    ):
+        """
+        Initialize the IgnoreMatcher object.
+
+        The passed paths (optional) are *added* to the list of
+        ignore paths from `const.common.IGNORE_PATHS`.
+
+        :param ignore_paths: List of paths to ignore (optional)
+        """
+        if ignore_paths is None:
+            ignore_paths = []
+
+        self.ignore_paths = ignore_paths + IGNORE_PATHS
+        self.ignore_binaries = ignore_binaries
+        self.ignore_large_files = ignore_large_files
+        self.root_path = root_path
+
+    def ignore(self, path: str) -> bool:
+        """
+        Check if the given path matches any of the ignore patterns.
+
+        Specified path can be either the full path, or a relative path
+        (if root_path was set in the constructor).
+
+        :param path: Path to the file or directory to check
+        :return: True if the path matches any of the ignore patterns, False otherwise
+        """
+
+        # Turn into absolute (full) path
+        if self.root_path and not path.startswith(self.root_path):
+            path = os.path.join(self.root_path, path)
+
+        if self.is_in_ignore_list(path):
+            return True
+
+        if self.ignore_large_files and self.is_large_file(path):
+            return True
+
+        if self.ignore_binaries and self.is_binary(path):
+            return True
+
+        return False
+
+    def is_in_ignore_list(self, path: str) -> bool:
+        """
+        Check if the given path matches any of the ignore patterns.
+
+        :param path: The path to the file or directory to check
+        :return: True if the path matches any of the ignore patterns, False otherwise.
+        """
+        name = os.path.basename(path)
+        for pattern in self.ignore_paths:
+            if fnmatch(name, pattern):
+                return True
+        return False
+
+    def is_large_file(self, path: str) -> bool:
+        """
+        Check if the given file is larger than the threshold.
+
+        :param path: FULL path to the file to check.
+        :return: True if the file is larger than the threshold, False otherwise.
+        """
+        if not os.path.isfile(path):
+            return False
+
+        return bool(os.path.getsize(path) > IGNORE_SIZE_THRESHOLD)
+
+    def is_binary(self, path: str) -> bool:
+        """
+        Check if the given file is binary.
+
+        :param path: FULL path to the file to check.
+        :return: True if the file is binary, False otherwise.
+        """
+        if not os.path.isfile(path):
+            return False
+
+        try:
+            open(path, "r", encoding="utf-8").read(128*1024)
+            return False
+        except UnicodeDecodeError:
+            return True


### PR DESCRIPTION
Ignore files that:

* match a specific pattern (eg `*.min.js`)
* are larger than 100KB
* are binary

Also allow user to specify file patterns in `IGNORE_PATHS`.

## Test

Test project folder structure/contents:

```
$ find . | grep -v 'node_modules/.\+' | grep -v '\.gpt-pilot/.\+'
.
./script.min.js
./node_modules
./pythagora.jpeg
./style.min.css
./webchat_application.zip
./package-lock.json
./.env
./.gpt-pilot
./tests
./server.js
./package.json
```

Note that `script.min.js`, `webchat_application.zip`, `style.min.css`, `pythagora.jpeg`, and the entire `test-app` is added from outside for testing purposes.

Files sent to the LLM (`breakdown_prompt_data.json` is the prompt data used for `breakdown.prompt`):

```
$ jq '.files[].full_path' breakdown_prompt_data.json 
"/home/senko/Projects/Pythagora/gpt-pilot/workspace/a3/package.json"
"/home/senko/Projects/Pythagora/gpt-pilot/workspace/a3/.env"
"/home/senko/Projects/Pythagora/gpt-pilot/workspace/a3/server.js"
```