### PR TITLE
Always replace small files + Count the number of created lines

### DIFF
--- a/pilot/helpers/agents/CodeMonkey.py
+++ b/pilot/helpers/agents/CodeMonkey.py
@@ -8,6 +8,8 @@ from helpers.files import get_file_contents
 from const.function_calls import GET_FILE_TO_MODIFY
 
 from utils.exit import trace_code_event
+from utils.telemetry import telemetry
+
 
 class CodeMonkey(Agent):
     save_dev_steps = True
@@ -112,6 +114,9 @@ class CodeMonkey(Agent):
             )
 
         if content and content != file_content:
+            if not self.project.skip_steps:
+                delta_lines = len(content.splitlines()) - len(file_content.splitlines())
+                telemetry.inc("created_lines", delta_lines)
             self.project.save_file({
                 'path': step['path'],
                 'name': step['name'],

--- a/pilot/helpers/agents/CodeMonkey.py
+++ b/pilot/helpers/agents/CodeMonkey.py
@@ -12,11 +12,19 @@ from utils.exit import trace_code_event
 class CodeMonkey(Agent):
     save_dev_steps = True
 
+    # Only attempt block-by-block replace if the file is larger than this many lines
+    SMART_REPLACE_THRESHOLD = 200
+
     def __init__(self, project, developer):
         super().__init__('code_monkey', project)
         self.developer = developer
 
-    def get_original_file(self, code_changes_description, step, files):
+    def get_original_file(
+            self,
+            code_changes_description: str,
+            step: dict[str, str],
+            files: list[dict],
+        ) -> tuple[str, str]:
         """
         Get the original file content and name.
 
@@ -77,8 +85,8 @@ class CodeMonkey(Agent):
         file_name, file_content = self.get_original_file(code_changes_description, step, files)
         content = file_content
 
-        if file_content:
-            # If we have the old file, try to replace individual code blocks
+        # If the file is non-empty and larger than the threshold, attempt to replace individual code blocks
+        if file_content and len(file_content.splitlines()) > self.SMART_REPLACE_THRESHOLD:
             replace_complete_file, content = self.replace_code_blocks(
                 step,
                 convo,
@@ -89,7 +97,7 @@ class CodeMonkey(Agent):
                 files,
             )
         else:
-            # We're creating a new file, so we need to get full output
+            # Just replace the entire file
             replace_complete_file = True
 
         # If this is a new file or replacing individual code blocks failed,
@@ -294,7 +302,7 @@ class CodeMonkey(Agent):
         :return: list of pairs of current and new blocks
         """
         pattern = re.compile(
-            r"CURRENT_CODE:\n```([a-z0-9]+)?\n(.*?)\n```\nNEW_CODE:\n```([a-z0-9]+)?\n(.*?)\n```\nEND\s*",
+            r"CURRENT_CODE:\n```([a-z0-9]+)?\n(.*?)\n```\nNEW_CODE:\n```([a-z0-9]+)?\n(.*?)\n?```\nEND\s*",
             re.DOTALL
         )
         pairs = []

--- a/pilot/helpers/agents/Developer.py
+++ b/pilot/helpers/agents/Developer.py
@@ -165,6 +165,10 @@ class Developer(Agent):
                 return {"success": True}
 
         data = step['save_file']
+        if not self.project.skip_steps:
+            delta_lines = len(data.get("content", "").splitlines())
+            telemetry.inc("created_lines", delta_lines)
+
         self.project.save_file(data)
         return {"success": True}
 

--- a/pilot/prompts/development/implement_changes.prompt
+++ b/pilot/prompts/development/implement_changes.prompt
@@ -7,7 +7,12 @@ This file needs to be modified by these instructions:
 {{ code_changes_description }}
 ----------------------end_of_instructions-----------------------------
 {% if full_output %}
-I want you to implement the instructions and show me the COMPLETE NEW VERSION of this file.
+I want you to implement the instructions and show me the COMPLETE NEW VERSION of this file in this format:
+-----------------------format----------------------------
+```
+the full contents of the updated file, without skipping over any content
+```
+------------------------end_of_format---------------------------
 **IMPORTANT**: Your reply should not omit any code in the new implementation or substitute anything with comments like `// .. rest of the code goes here ..`, because I will overwrite the existing file with the content you provide. Output ONLY the content for this file, without additional explanation.
 {% else %}
 I want you to implement the instructions and show me the exact changes (`diff`) in the file `{{ file_name }}`. Reply only with the modifications (`diff`) in the following format:

--- a/pilot/utils/telemetry.py
+++ b/pilot/utils/telemetry.py
@@ -124,6 +124,8 @@ class Telemetry:
             "num_tasks": 0,
             # Number of seconds elapsed during development
             "elapsed_time": 0,
+            # Total number of lines created by GPT Pilot
+            "created_lines": 0,
             # End result of development:
             # - success:initial-project
             # - success:feature


### PR DESCRIPTION
This PR contains two changes:

1. CodeMonkey now always outputs full file content for files that are less than 200 lines long (1st commit)
2. We now count the number of created lines of code and include it in the telemetry as `created_lines` (2nd commit)

Note that the count is per session. To get the complete number, we need to sum up all the `created_lines` for an app.

Example telemetry entry:
 
![Screenshot from 2024-01-24 09-54-09](https://github.com/Pythagora-io/gpt-pilot/assets/3362/9b610357-7a95-4dc2-84f9-b807cb43f5c7)
