### PR TITLE
Handle openai errors

### DIFF
--- a/pilot/const/llm.py
+++ b/pilot/const/llm.py
@@ -3,3 +3,5 @@ MAX_GPT_MODEL_TOKENS = int(os.getenv('MAX_TOKENS', 8192))
 MIN_TOKENS_FOR_GPT_RESPONSE = 600
 MAX_QUESTIONS = 5
 END_RESPONSE = "EVERYTHING_CLEAR"
+API_CONNECT_TIMEOUT = 30  # timeout for connecting to the API and sending the request (seconds)
+API_READ_TIMEOUT = 300  # timeout for receiving the response (seconds)

--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -5,7 +5,7 @@ import uuid
 from utils.style import color_yellow, color_yellow_bold
 
 from database.database import get_saved_development_step, save_development_step, delete_all_subsequent_steps
-from helpers.exceptions.TokenLimitError import TokenLimitError
+from helpers.exceptions import TokenLimitError
 from utils.function_calling import parse_agent_response, FunctionCallSet
 from utils.llm_connection import create_gpt_chat_completion
 from utils.utils import get_prompt, get_sys_message, capitalize_first_word_with_underscores

--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -2,10 +2,11 @@ import json
 import re
 import subprocess
 import uuid
-from utils.style import color_yellow, color_yellow_bold
+from traceback import format_exc
+from utils.style import color_yellow, color_yellow_bold, color_red_bold
 
 from database.database import get_saved_development_step, save_development_step, delete_all_subsequent_steps
-from helpers.exceptions import TokenLimitError
+from helpers.exceptions import TokenLimitError, ApiError
 from utils.function_calling import parse_agent_response, FunctionCallSet
 from utils.llm_connection import create_gpt_chat_completion
 from utils.utils import get_prompt, get_sys_message, capitalize_first_word_with_underscores
@@ -95,11 +96,21 @@ class AgentConvo:
         # TODO handle errors from OpenAI
         # It's complicated because calling functions are expecting different types of responses - string or tuple
         # https://github.com/Pythagora-io/gpt-pilot/issues/165 & #91
-        if response == {}:
+        if response == {} or response is None:
+            # This should never happen since we're raising ApiError in create_gpt_chat_completion
+            # Leaving this in place in case there's a case where this can still happen
             logger.error('Aborting with "OpenAI API error happened"')
-            raise Exception("OpenAI API error happened.")
+            print(color_red_bold('There was an error talking to OpenAI API. Please try again later.'))
+            payload_size_kb = len(json.dumps(self.messages)) // 1000
+            raise ApiError(f"Unknown API error (prompt: {prompt_path}, request size: {payload_size_kb}KB)")
 
-        response = parse_agent_response(response, function_calls)
+        try:
+            response = parse_agent_response(response, function_calls)
+        except (KeyError, json.JSONDecodeError) as err:
+            logger.error("Error while parsing LLM response: {err.__class__.__name__}: {err}")
+            print(color_red_bold(f'There was an error parsing LLM response: \"{err.__class__.__name__}: {err}\". Please try again later.'))
+            raise ApiError(f"Error parsing LLM response: {err.__class__.__name__}: {err}: Response text: {response}") from err
+
         message_content = self.format_message_content(response, function_calls)
 
         # TODO we need to specify the response when there is a function called

--- a/pilot/helpers/Debugger.py
+++ b/pilot/helpers/Debugger.py
@@ -6,8 +6,8 @@ from const.code_execution import MAX_COMMAND_DEBUG_TRIES, MAX_RECUSION_LAYER
 from const.function_calls import DEBUG_STEPS_BREAKDOWN
 from const.messages import AFFIRMATIVE_ANSWERS, NEGATIVE_ANSWERS
 from helpers.AgentConvo import AgentConvo
-from helpers.exceptions.TokenLimitError import TokenLimitError
-from helpers.exceptions.TooDeepRecursionError import TooDeepRecursionError
+from helpers.exceptions import TokenLimitError
+from helpers.exceptions import TooDeepRecursionError
 from logger.logger import logger
 from prompts.prompts import ask_user
 

--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -12,7 +12,7 @@ from const.common import STEPS
 from database.database import delete_unconnected_steps_from, delete_all_app_development_data, update_app_status
 from const.ipc import MESSAGE_TYPE
 from prompts.prompts import ask_user
-from helpers.exceptions.TokenLimitError import TokenLimitError
+from helpers.exceptions import TokenLimitError
 from utils.questionary import styled_text
 from helpers.files import get_directory_contents, get_file_contents, clear_directory, update_file
 from helpers.cli import build_directory_tree

--- a/pilot/helpers/agents/Developer.py
+++ b/pilot/helpers/agents/Developer.py
@@ -12,9 +12,9 @@ from utils.style import (
     color_cyan_bold,
     color_white_bold
 )
-from helpers.exceptions.TokenLimitError import TokenLimitError
+from helpers.exceptions import TokenLimitError
 from const.code_execution import MAX_COMMAND_DEBUG_TRIES
-from helpers.exceptions.TooDeepRecursionError import TooDeepRecursionError
+from helpers.exceptions import TooDeepRecursionError
 from helpers.Debugger import Debugger
 from utils.questionary import styled_text
 from utils.utils import step_already_finished

--- a/pilot/helpers/cli.py
+++ b/pilot/helpers/cli.py
@@ -12,9 +12,9 @@ from logger.logger import logger
 from utils.style import color_yellow, color_green, color_red, color_yellow_bold
 from utils.ignore import IgnoreMatcher
 from database.database import get_saved_command_run, save_command_run
-from helpers.exceptions.TooDeepRecursionError import TooDeepRecursionError
-from helpers.exceptions.TokenLimitError import TokenLimitError
-from helpers.exceptions.CommandFinishedEarly import CommandFinishedEarly
+from helpers.exceptions import TooDeepRecursionError
+from helpers.exceptions import TokenLimitError
+from helpers.exceptions import CommandFinishedEarly
 from prompts.prompts import ask_user
 from const.code_execution import MIN_COMMAND_RUN_TIME, MAX_COMMAND_RUN_TIME, MAX_COMMAND_OUTPUT_LENGTH
 from const.messages import AFFIRMATIVE_ANSWERS, NEGATIVE_ANSWERS

--- a/pilot/helpers/exceptions.py
+++ b/pilot/helpers/exceptions.py
@@ -1,0 +1,26 @@
+from const.llm import MAX_GPT_MODEL_TOKENS
+
+
+class ApiKeyNotDefinedError(Exception):
+    def __init__(self, env_key: str):
+        self.env_key = env_key
+        super().__init__(f"API Key has not been configured: {env_key}")
+
+
+class CommandFinishedEarly(Exception):
+    def __init__(self, message='Command finished before timeout. Handling early completion...'):
+        self.message = message
+        super().__init__(message)
+
+
+class TokenLimitError(Exception):
+    def __init__(self, tokens_in_messages, max_tokens=MAX_GPT_MODEL_TOKENS):
+        self.tokens_in_messages = tokens_in_messages
+        self.max_tokens = max_tokens
+        super().__init__(f"Token limit error happened with {tokens_in_messages}/{max_tokens} tokens in messages!")
+
+
+class TooDeepRecursionError(Exception):
+    def __init__(self, message='Recursion is too deep!'):
+        self.message = message
+        super().__init__(message)

--- a/pilot/helpers/exceptions.py
+++ b/pilot/helpers/exceptions.py
@@ -24,3 +24,9 @@ class TooDeepRecursionError(Exception):
     def __init__(self, message='Recursion is too deep!'):
         self.message = message
         super().__init__(message)
+
+
+class ApiError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)

--- a/pilot/helpers/exceptions/ApiKeyNotDefinedError.py
+++ b/pilot/helpers/exceptions/ApiKeyNotDefinedError.py
@@ -1,4 +1,0 @@
-class ApiKeyNotDefinedError(Exception):
-    def __init__(self, env_key: str):
-        self.env_key = env_key
-        super().__init__(f"API Key has not been configured: {env_key}")

--- a/pilot/helpers/exceptions/CommandFinishedEarly.py
+++ b/pilot/helpers/exceptions/CommandFinishedEarly.py
@@ -1,4 +1,0 @@
-class CommandFinishedEarly(Exception):
-    def __init__(self, message='Command finished before timeout. Handling early completion...'):
-        self.message = message
-        super().__init__(message)

--- a/pilot/helpers/exceptions/TokenLimitError.py
+++ b/pilot/helpers/exceptions/TokenLimitError.py
@@ -1,8 +1,0 @@
-from const.llm import MAX_GPT_MODEL_TOKENS
-
-
-class TokenLimitError(Exception):
-    def __init__(self, tokens_in_messages, max_tokens=MAX_GPT_MODEL_TOKENS):
-        self.tokens_in_messages = tokens_in_messages
-        self.max_tokens = max_tokens
-        super().__init__(f"Token limit error happened with {tokens_in_messages}/{max_tokens} tokens in messages!")

--- a/pilot/helpers/exceptions/TooDeepRecursionError.py
+++ b/pilot/helpers/exceptions/TooDeepRecursionError.py
@@ -1,4 +1,0 @@
-class TooDeepRecursionError(Exception):
-    def __init__(self, message='Recursion is too deep!'):
-        self.message = message
-        super().__init__(message)

--- a/pilot/helpers/exceptions/__init__.py
+++ b/pilot/helpers/exceptions/__init__.py
@@ -1,3 +1,0 @@
-from .ApiKeyNotDefinedError import ApiKeyNotDefinedError
-from .TokenLimitError import TokenLimitError
-from .TooDeepRecursionError import TooDeepRecursionError

--- a/pilot/main.py
+++ b/pilot/main.py
@@ -23,7 +23,7 @@ from database.database import database_exists, create_database, tables_exist, cr
 
 from utils.settings import settings, loader
 from utils.telemetry import telemetry
-
+from helpers.exceptions import ApiError, TokenLimitError
 
 def init():
     # Check if the "euclid" database exists, if not, create it
@@ -103,6 +103,11 @@ if __name__ == "__main__":
                 telemetry.set("end_result", "failure:api-error")
                 print('Exit', type='exit')
 
+    except (ApiError, TokenLimitError) as err:
+        telemetry.record_crash(err, end_result="failure:api-error")
+        telemetry.send()
+        run_exit_fn = False
+        print('Exit', type='exit')
     except KeyboardInterrupt:
         telemetry.set("end_result", "interrupt")
         if project.check_ipc():

--- a/pilot/prompts/prompts.py
+++ b/pilot/prompts/prompts.py
@@ -6,6 +6,7 @@ from utils.llm_connection import create_gpt_chat_completion
 from utils.utils import get_sys_message, get_prompt
 from utils.questionary import styled_select, styled_text
 from logger.logger import logger
+from helpers.exceptions import ApiError
 
 
 def ask_for_app_type():
@@ -88,7 +89,10 @@ def get_additional_info_from_openai(project, messages):
     while not is_complete:
         # Obtain clarifications using the OpenAI API
         # { 'text': new_code }
-        response = create_gpt_chat_completion(messages, 'additional_info', project)
+        try:
+            response = create_gpt_chat_completion(messages, 'additional_info', project)
+        except ApiError:
+            response = None
 
         if response is not None:
             if response['text'] and response['text'].strip() == END_RESPONSE:

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -11,7 +11,7 @@ from prompt_toolkit.styles import Style
 from jsonschema import validate, ValidationError
 from utils.style import color_red
 from typing import List
-from const.llm import MAX_GPT_MODEL_TOKENS
+from const.llm import MAX_GPT_MODEL_TOKENS, API_CONNECT_TIMEOUT, API_READ_TIMEOUT
 from const.messages import AFFIRMATIVE_ANSWERS
 from logger.logger import logger, logging
 from helpers.exceptions import TokenLimitError, ApiKeyNotDefinedError, ApiError
@@ -380,7 +380,8 @@ def stream_gpt_completion(data, req_type, project):
         endpoint_url,
         headers=headers,
         json=data,
-        stream=True
+        stream=True,
+        timeout=(API_CONNECT_TIMEOUT, API_READ_TIMEOUT),
     )
 
     if response.status_code != 200:

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -5,6 +5,7 @@ import sys
 import time
 import json
 import tiktoken
+from traceback import format_exc
 from prompt_toolkit.styles import Style
 
 from jsonschema import validate, ValidationError
@@ -13,7 +14,7 @@ from typing import List
 from const.llm import MAX_GPT_MODEL_TOKENS
 from const.messages import AFFIRMATIVE_ANSWERS
 from logger.logger import logger, logging
-from helpers.exceptions import TokenLimitError, ApiKeyNotDefinedError
+from helpers.exceptions import TokenLimitError, ApiKeyNotDefinedError, ApiError
 from utils.utils import fix_json, get_prompt
 from utils.function_calling import add_function_calls_to_request, FunctionCallSet, FunctionType
 from utils.questionary import styled_text
@@ -142,10 +143,11 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
         raise e
     except Exception as e:
         logger.error(f'The request to {os.getenv("ENDPOINT")} API failed: %s', e)
-        print(f'The request to {os.getenv("ENDPOINT")} API failed. Here is the error message:')
-        print(e)
-        return {}   # https://github.com/Pythagora-io/gpt-pilot/issues/130 - may need to revisit how we handle this
-
+        print(color_red(f'The request to {os.getenv("ENDPOINT")} API failed with error: {e}. Please try again later.'))
+        if isinstance(e, ApiError):
+            raise e
+        else:
+            raise ApiError("Error making LLM API request: {e}") from e
 
 def delete_last_n_lines(n):
     for _ in range(n):
@@ -245,7 +247,9 @@ def retry_on_exception(func):
                 if "context_length_exceeded" in err_str:
                     # If the specific error "context_length_exceeded" is present, simply return without retry
                     # spinner_stop(spinner)
-                    raise TokenLimitError(get_tokens_in_messages_from_openai_error(err_str), MAX_GPT_MODEL_TOKENS)
+                    n_tokens = get_tokens_in_messages_from_openai_error(err_str)
+                    print(color_red(f"Error calling LLM API: The request exceeded the maximum token limit (request size: {n_tokens}) tokens."))
+                    raise TokenLimitError(n_tokens, MAX_GPT_MODEL_TOKENS)
                 if "rate_limit_exceeded" in err_str:
                     # Extracting the duration from the error string
                     match = re.search(r"Please try again in (\d+)ms.", err_str)
@@ -279,7 +283,10 @@ def retry_on_exception(func):
                 # TODO: take user's input into consideration - send to LLM?
                 # https://github.com/Pythagora-io/gpt-pilot/issues/122
                 if user_message.lower() not in AFFIRMATIVE_ANSWERS:
-                    return {}
+                    if isinstance(e, ApiError):
+                        raise
+                    else:
+                        raise ApiError(f"Error making LLM API request: {err_str}") from e
 
     return wrapper
 
@@ -380,7 +387,7 @@ def stream_gpt_completion(data, req_type, project):
         project.dot_pilot_gpt.log_chat_completion(endpoint, model, req_type, data['messages'], response.text)
         logger.info(f'problem with request (status {response.status_code}): {response.text}')
         telemetry.record_llm_request(token_count, time.time() - request_start_time, is_error=True)
-        raise Exception(f"API responded with status code: {response.status_code}. Response text: {response.text}")
+        raise ApiError(f"API responded with status code: {response.status_code}. Request token size: {token_count} tokens. Response text: {response.text}")
 
     # function_calls = {'name': '', 'arguments': ''}
 

--- a/pilot/utils/telemetry.py
+++ b/pilot/utils/telemetry.py
@@ -242,6 +242,7 @@ class Telemetry:
     def record_crash(
         self,
         exception: Exception,
+        end_result: str = "failure",
     ):
         """
         Record crash diagnostics.
@@ -256,7 +257,7 @@ class Telemetry:
         if not self.enabled:
             return
 
-        self.set("end_result", "failure")
+        self.set("end_result", end_result)
 
         root_dir = Path(__file__).parent.parent.parent
         stack_trace = traceback.format_exc()


### PR DESCRIPTION
Instead of crashing with an ugly stack trace, we now nicely show the error to the user. We still exit tho, this doesn't add any additional recovery mechanisms. We also still log this as a failure (of type `failure:api-error`) and include crash diagnostics so we can see any anomalies if the happen.

1. Timeout error:
![Screenshot from 2024-01-27 13-26-23](https://github.com/Pythagora-io/gpt-pilot/assets/3362/c1c7f5c4-0d23-4a38-bb71-b4dbf1323524)

2. Request too large (context size / token limit error):
![Screenshot from 2024-01-27 13-20-33](https://github.com/Pythagora-io/gpt-pilot/assets/3362/0f58edb0-ff6e-49a3-b564-f180ffdc7e24)

3. Error when the LLM response cannot be correctly parsed:
![Screenshot from 2024-01-27 13-42-18](https://github.com/Pythagora-io/gpt-pilot/assets/3362/f152d449-3433-4886-91fb-bf0771f68df8)

4. Generic error from the API:
![Screenshot from 2024-01-27 13-00-31](https://github.com/Pythagora-io/gpt-pilot/assets/3362/8c3dc0d1-c4d7-47ae-bc0d-123ccf8aa7ee)

Note: The API key error should never happen because we first check the key/endpoint before starting the app (the check was disabled in this instance for testing purposes), but this will catch any generic error from the API (including SSL/connection errors).

