### PR TITLE
Fix crashes when file already exists with different full path

### DIFF
--- a/pilot/helpers/Project.py
+++ b/pilot/helpers/Project.py
@@ -471,7 +471,7 @@ class Project:
                 app=self.app,
                 name=file['name'],
                 path=file['path'],
-                full_path=file['full_path'],
+                defaults={'full_path': file['full_path']},
             )
 
             file_snapshot, created = FileSnapshot.get_or_create(


### PR DESCRIPTION
Stop crashes if file already exists in the database with a different full_path:

```
File "/Users/user/Documents/test/gpt-pilot/pilot/helpers/agents/Developer.py", line 367, in get_run_command
    llm_response = convo.send_message('development/get_run_command.prompt', {}, COMMAND_TO_RUN)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Documents/test/gpt-pilot/pilot/helpers/AgentConvo.py", line 74, in send_message
    save_development_step(self.agent.project, prompt_path, prompt_data, self.messages, response)
  File "/Users/user/Documents/test/gpt-pilot/pilot/database/database.py", line 301, in save_development_step
    project.save_files_snapshot(development_step.id)
  File "/Users/user/Documents/test/gpt-pilot/pilot/helpers/Project.py", line 470, in save_files_snapshot
    file_in_db, created = File.get_or_create(
                          ^^^^^^^^^^^^^^^^^^^
  File "/Users/user/Documents/test/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 6732, in get_or_create
    raise exc
  ...
  File "/Users/user/Documents/test/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 3251, in execute_sql
    cursor.execute(sql, params or ())
peewee.IntegrityError: UNIQUE constraint failed: file.app_id, file.name, file.path
```

