### PR TITLE
Show rate limit error message from OpenAI

### DIFF
--- a/pilot/helpers/exceptions.py
+++ b/pilot/helpers/exceptions.py
@@ -1,3 +1,5 @@
+import json
+
 from const.llm import MAX_GPT_MODEL_TOKENS
 
 
@@ -27,8 +29,16 @@ class TooDeepRecursionError(Exception):
 
 
 class ApiError(Exception):
-    def __init__(self, message):
+    def __init__(self, message, response=None):
         self.message = message
+        self.response = response
+        self.response_json = None
+        if response and hasattr(response, "text"):
+            try:
+                self.response_json = json.loads(response.text)
+            except Exception:  # noqa
+                pass
+
         super().__init__(message)
 
 

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -9,7 +9,7 @@ from traceback import format_exc
 from prompt_toolkit.styles import Style
 
 from jsonschema import validate, ValidationError
-from utils.style import color_red
+from utils.style import color_red, color_yellow
 from typing import List
 from const.llm import MAX_GPT_MODEL_TOKENS, API_CONNECT_TIMEOUT, API_READ_TIMEOUT
 from const.messages import AFFIRMATIVE_ANSWERS
@@ -147,7 +147,7 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
         if isinstance(e, ApiError):
             raise e
         else:
-            raise ApiError("Error making LLM API request: {e}") from e
+            raise ApiError(f"Error making LLM API request: {e}") from e
 
 def delete_last_n_lines(n):
     for _ in range(n):
@@ -261,7 +261,14 @@ def retry_on_exception(func):
                             # waiting 6ms isn't usually long enough - exponential back-off until about 6 seconds
                             wait_duration_ms *= 2
                         logger.debug(f'Rate limited. Waiting {wait_duration_ms}ms...')
-                        time.sleep(wait_duration_ms / 1000)
+                        wait_duration_sec = int(wait_duration_ms / 1000) + 1
+                        if isinstance(e, ApiError) and hasattr(e, "response_json") and e.response_json is not None and "error" in e.response_json:
+                            message = e.response_json["error"]["message"]
+                        else:
+                            message = "Rate limited by the API (we're over 'tokens per minute' or 'requests per minute' limit)"
+                        print(color_yellow(message))
+                        print(color_yellow(f"Retrying in {wait_duration_sec} second(s)..."))
+                        time.sleep(wait_duration_sec)
                     continue
 
                 print(color_red('There was a problem with request to openai API:'))
@@ -388,7 +395,7 @@ def stream_gpt_completion(data, req_type, project):
         project.dot_pilot_gpt.log_chat_completion(endpoint, model, req_type, data['messages'], response.text)
         logger.info(f'problem with request (status {response.status_code}): {response.text}')
         telemetry.record_llm_request(token_count, time.time() - request_start_time, is_error=True)
-        raise ApiError(f"API responded with status code: {response.status_code}. Request token size: {token_count} tokens. Response text: {response.text}")
+        raise ApiError(f"API responded with status code: {response.status_code}. Request token size: {token_count} tokens. Response text: {response.text}", response=response)
 
     # function_calls = {'name': '', 'arguments': ''}
 

--- a/pilot/utils/test_llm_connection.py
+++ b/pilot/utils/test_llm_connection.py
@@ -370,7 +370,7 @@ class TestLlmConnection:
 
         error_text = '''{
                 "error": {
-                    "message": "Rate limit reached for 10KTPM-200RPM in organization org-OASFC7k1Ff5IzueeLArhQtnT on tokens per min. Limit: 10000 / min. Please try again in 6ms. Contact us through our help center at help.openai.com if you continue to have issues.",
+                    "message": "Rate limit reached for 10KTPM-200RPM in organization org-OASFC7k1Ff5IzueeLArhQtnT on tokens per min. Limit: 10000 / min. Please try again in 750ms. Contact us through our help center at help.openai.com if you continue to have issues.",
                     "type": "tokens",
                     "param": null,
                     "code": "rate_limit_exceeded"
@@ -387,9 +387,7 @@ class TestLlmConnection:
         mock_response.status_code = 200
         mock_response.iter_lines.return_value = [success_text.encode('utf-8')]
 
-        mock_post.side_effect = [error_response, error_response, error_response, error_response, error_response,
-                                 error_response, error_response, error_response, error_response, error_response,
-                                 error_response, error_response, mock_response]
+        mock_post.side_effect = [error_response, error_response, error_response, error_response, error_response, mock_response]
         wrapper = retry_on_exception(stream_gpt_completion)
         data = {
             'model': 'gpt-4',
@@ -401,11 +399,7 @@ class TestLlmConnection:
 
         # Then
         assert response == {'text': 'DONE'}
-        # assert mock_sleep.call_count == 9
-        assert mock_sleep.call_args_list == [call(0.006), call(0.012), call(0.024), call(0.048), call(0.096),
-                                             call(0.192), call(0.384), call(0.768), call(1.536), call(3.072),
-                                             call(6.144), call(6.144)]
-        # mock_sleep.call
+        assert mock_sleep.call_args_list == [call(1), call(2), call(4), call(7), call(7)]
 
     @patch('utils.llm_connection.requests.post')
     def test_stream_gpt_completion(self, mock_post, monkeypatch):


### PR DESCRIPTION
This shows the rate limit messages so that users understand why GPT Pilot is "waiting..."

![Screenshot from 2024-01-31 10-26-47](https://github.com/Pythagora-io/gpt-pilot/assets/3362/1d23f395-67df-473c-8f62-43f50bd751f1)

Retry mechanism is not changed, just that we now wait for whole seconds. The exponential backoff remains `double each time until you go over 6s, then keep it constant` (see screenshot).