### PR TITLE
fix change reviewer retries in case the number of hunks doesn't match up

### DIFF
--- a/pilot/helpers/agents/CodeMonkey.py
+++ b/pilot/helpers/agents/CodeMonkey.py
@@ -223,8 +223,6 @@ class CodeMonkey(Agent):
                 error = "Not all hunks have been reviewed. Please review all hunks and add 'apply' or 'ignore' decision for each."
             elif n_review_hunks > n_hunks:
                 error = f"Your review contains more hunks ({n_review_hunks}) than in the original diff ({n_hunks}). Note that one hunk may have multiple changed lines."
-            if len(ids_to_apply | ids_to_ignore) == len(hunks):
-                break
 
             # Max two retries; if the reviewer still hasn't reviewed all hunks, we'll just use the entire new content
             llm_response = convo.send_message(
@@ -236,6 +234,7 @@ class CodeMonkey(Agent):
             messages_to_remove += 2
         else:
             # The reviewer failed to review all the hunks in 3 attempts, let's just use all the new content
+            convo.remove_last_x_messages(messages_to_remove)
             return new_content
 
         convo.remove_last_x_messages(messages_to_remove)

--- a/pilot/prompts/components/steps_list.prompt
+++ b/pilot/prompts/components/steps_list.prompt
@@ -2,7 +2,7 @@
 The current task has been split into multiple steps, and each step is one of the following:
 * `command` - command to run
 * `save_file` -  create a NEW file
-* `modify_file` - update ONE EXISTING file
+* `modify_file` or `code_change` - update ONE EXISTING file
 * `human_intervention` - if the human needs to do something
 
 {% if step_index > 0 %}Here is the list of steps that have been executed:

--- a/pilot/prompts/development/review_changes.prompt
+++ b/pilot/prompts/development/review_changes.prompt
@@ -17,7 +17,11 @@ Here is the diff of the changes:
 ```
 {% endfor %}
 
+As you can see, there {% if hunks|length == 1 %}is only one hunk in this diff, and it{% else %}are {hunks|length} hunks in this diff, and each{% endif %} starts with the `@@` header line.
+
 Think carefully about the instructions and review the proposed changes. For each hunk of change, decide whether it should be applied or should be ignored (for example if it is a code deletion or change that wasn't asked for). Finally, if the changes miss something that was in the instructions, mention that.
+
+Note that the developer may add logging (including `gpt_pilot_debugging_log`) or error handling that's not explicitly asked for, but is a part of good development practice. Unless these logging and error handling additions break something, you should not ignore those changes.
 
 Here is an example output if 3 of 4 hunks in the change should be applied and one of them should be ignored, and no other changes are needed:
 ```


### PR DESCRIPTION
Fix feedback to the reviewer in case the number of hunks in review doesn't match up with the number in the change.

Also make it clear to the reviewer that it's okay if the developer added some extra logging, as long as that doesn't break anything.