### PR TITLE
Convince get-run-command to use paths relative to project root.

### DIFF
--- a/pilot/prompts/development/get_run_command.prompt
+++ b/pilot/prompts/development/get_run_command.prompt
@@ -3,5 +3,7 @@ How can I run this app?
 Do not reply with anything else but the command with which I can run this app with.
 For example, if the command is "python app.py", then your response needs to be only `python app.py` without the `
 
+Pay attention to file paths: if the command or argument is a file or folder from the project, use paths relative to the project root (for example, use `./somefile` instead of `/somefile`).
+
 If there is no command to run reply with empty response.
 For example, if we only setup package.json and no other files are coded there is no command to run so respond with `` without the `


### PR DESCRIPTION
Previously, there was 1/10 chance of the command to incorrectly use absolute paths, because that's how we refer to files in the project root directory, like this:

```
go run /main.go
```

With this change, it's less than 1/50, and the command becomes:

```
go run ./main.go
```
