### PR TITLE
reorder reasoning to be before decision in reviewer prompt

### DIFF
--- a/pilot/const/function_calls.py
+++ b/pilot/const/function_calls.py
@@ -731,17 +731,17 @@ REVIEW_CHANGES = {
                                 "type": "integer",
                                 "description": "Index of the hunk in the diff. Starts from 1."
                             },
+                            "reason": {
+                                "type": "string",
+                                "desciprion": "Reason for applying or ignoring this hunk."
+                            },
                             "decision": {
                                 "type": "string",
                                 "enum": ["apply", "ignore"],
                                 "description": "Whether to apply this hunk (if it's a valid change) or ignore it."
-                            },
-                            "reason": {
-                                "type": "string",
-                                "desciprion": "Reason for allowing or ignoring this hunk."
                             }
                         },
-                        "required": ["number", "decision", "reason"],
+                        "required": ["number", "reason", "decision"],
                         "additionalProperties": False
                     },
                 },

--- a/pilot/prompts/development/review_changes.prompt
+++ b/pilot/prompts/development/review_changes.prompt
@@ -29,23 +29,23 @@ Here is an example output if 3 of 4 hunks in the change should be applied and on
     "hunks": [
         {
             "number": 1,
-            "decision": "apply",
             "reason": "Some explanation why this part of the change is important",
+            "decision": "apply"
         },
         {
             "number": 2,
-            "decision": "apply",
             "reason": "Another explanation, for the 2nd hunk",
+            "decision": "apply"
         },
         {
             "number": 3,
-            "decision": "ignore",
             "reason": "This hunk accidentally deletes important code",
+            "decision": "ignore"
         },
         {
             "number": 4,
-            "decision": "apply",
             "reason": "Explanation why the fourth hunk should be included in the change",
+            "decision": "apply"
         },
     ],
     "review_notes": "General review notes, if something is missing from the change you can comment about it here"


### PR DESCRIPTION
Example LLM response:

```json
{
    "hunks": [
        {
            "number": 1,
            "reason": "The change improves MongoDB connection handling with promise chaining and proper error logging. It's a refinement rather than a requested modification, but it enhances the application's resilience and error reporting.",
            "decision": "apply"
        },
        {
            "number": 2,
            "reason": "Correctly adds the setup for EJS as the rendering engine and defines the views directory as requested. The additional log indicating EJS setup is useful for debugging purposes.",
            "decision": "apply"
        },
        {
            "number": 3,
            "reason": "Updates error handling for better clarity by removing '.stack', aligning with changes made in Hunk 1 for consistent error logging.",
            "decision": "apply"
        }
    ],
    "review_notes": "Overall, the changes align well with the task requirements and include improvements in error handling and logging. There were no deletions of necessary code, and the modifications adhere to good development practices."
}
```