### PR TITLE
Added model override for agents.

### DIFF
--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -10,8 +10,18 @@ AZURE_ENDPOINT=
 OPENROUTER_API_KEY=
 
 # In case of Azure/OpenRouter endpoint, change this to your deployed model name
-MODEL_NAME=gpt-4-turbo-preview
 MAX_TOKENS=8192
+
+# Override model for an agent 
+#FULL_STACK_DEVELOPER_MODEL_NAME=gpt-4-turbo-preview
+#CODE_MONKEY_MODEL_NAME=gpt-4-turbo-preview
+#ARCHITECT_MODEL_NAME=gpt-4-turbo-preview
+#PRODUCT_OWNER_MODEL_NAME=gpt-4-turbo-preview
+#TECH_LEAD_MODEL_NAME=gpt-4-turbo-preview
+#DEV_OPS_MODEL_NAME=gpt-4-turbo-preview
+#TECHNICAL_WRITER_MODEL_NAME=gpt-4-turbo-preview
+DEFAULT_MODEL_NAME=gpt-4-turbo-preview
+
 
 # Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)
 # IGNORE_PATHS=folder1,folder2

--- a/pilot/helpers/Agent.py
+++ b/pilot/helpers/Agent.py
@@ -1,4 +1,23 @@
+import os
+
+from helpers import Project
+
+
 class Agent:
-    def __init__(self, role, project):
+    
+    modle: str;
+    project: Project;
+
+    def __init__(self, role: str, project: Project):
         self.role = role
         self.project = project
+        self.modle = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4-turbo-preview');
+
+        agentModelName = f'{role.upper()}_MODEL_NAME';
+        if agentModelName in os.environ:
+            self.modle = os.getenv(agentModelName, 'gpt-4-turbo-preview');
+
+        
+
+
+        

--- a/pilot/helpers/Agent.py
+++ b/pilot/helpers/Agent.py
@@ -1,21 +1,18 @@
 import os
 
-from helpers import Project
-
 
 class Agent:
     
-    modle: str;
-    project: Project;
+    model: str;
 
-    def __init__(self, role: str, project: Project):
+    def __init__(self, role: str, project):
         self.role = role
         self.project = project
-        self.modle = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4-turbo-preview');
+        self.model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4-turbo-preview');
 
         agentModelName = f'{role.upper()}_MODEL_NAME';
         if agentModelName in os.environ:
-            self.modle = os.getenv(agentModelName, 'gpt-4-turbo-preview');
+            self.model = os.getenv(agentModelName, 'gpt-4-turbo-preview');
 
         
 

--- a/pilot/helpers/Agent.py
+++ b/pilot/helpers/Agent.py
@@ -3,16 +3,16 @@ import os
 
 class Agent:
     
-    model: str;
+    model: str
 
     def __init__(self, role: str, project):
         self.role = role
         self.project = project
-        self.model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4-turbo-preview');
+        self.model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4-turbo-preview')
 
-        agentModelName = f'{role.upper()}_MODEL_NAME';
+        agentModelName = f'{role.upper()}_MODEL_NAME'
         if agentModelName in os.environ:
-            self.model = os.getenv(agentModelName, 'gpt-4-turbo-preview');
+            self.model = os.getenv(agentModelName, 'gpt-4-turbo-preview')
 
         
 

--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import uuid
 from os.path import sep
+from pilot.helpers import Agent
 
 from utils.style import color_yellow, color_yellow_bold, color_red_bold
 from database.database import save_development_step
@@ -17,6 +18,7 @@ from helpers.cli import running_processes
 
 
 class AgentConvo:
+    agent: Agent;
     """
     Represents a conversation with an agent.
 
@@ -24,7 +26,7 @@ class AgentConvo:
         agent: An instance of the agent participating in the conversation.
     """
 
-    def __init__(self, agent):
+    def __init__(self, agent: Agent):
         # [{'role': 'system'|'user'|'assistant', 'content': ''}, ...]
         self.messages: list[dict] = []
         self.branches = {}
@@ -62,7 +64,7 @@ class AgentConvo:
 
         try:
             self.replace_files()
-            response = create_gpt_chat_completion(self.messages, self.high_level_step, self.agent.project,
+            response = create_gpt_chat_completion(self.messages, self.high_level_step, self.agent.project, self.agent.model,
                                                   function_calls=function_calls, prompt_data=prompt_data)
         except TokenLimitError as e:
             save_development_step(self.agent.project, prompt_path, prompt_data, self.messages, '', str(e))

--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -18,7 +18,7 @@ from helpers.cli import running_processes
 
 
 class AgentConvo:
-    agent: Agent;
+    agent: Agent
     """
     Represents a conversation with an agent.
 

--- a/pilot/helpers/agents/ProductOwner.py
+++ b/pilot/helpers/agents/ProductOwner.py
@@ -95,7 +95,7 @@ class ProductOwner(Agent):
         instructions = generate_messages_from_description(main_prompt,
                                                           self.project.args['app_type'],
                                                           self.project.args['name'])
-        return get_additional_info_from_openai(self.project, instructions)
+        return get_additional_info_from_openai(self.project, instructions, self.modle)
 
     def generate_project_summary(self, high_level_messages: list[dict]):
         print(color_green_bold('Project Summary:\n'))

--- a/pilot/helpers/agents/ProductOwner.py
+++ b/pilot/helpers/agents/ProductOwner.py
@@ -95,7 +95,7 @@ class ProductOwner(Agent):
         instructions = generate_messages_from_description(main_prompt,
                                                           self.project.args['app_type'],
                                                           self.project.args['name'])
-        return get_additional_info_from_openai(self.project, instructions, self.modle)
+        return get_additional_info_from_openai(self.project, instructions, self.model)
 
     def generate_project_summary(self, high_level_messages: list[dict]):
         print(color_green_bold('Project Summary:\n'))

--- a/pilot/helpers/agents/__init__.py
+++ b/pilot/helpers/agents/__init__.py
@@ -1,3 +1,5 @@
 from .Architect import Architect, ARCHITECTURE_STEP
 from .Developer import Developer, ENVIRONMENT_SETUP_STEP
 from .TechLead import TechLead
+from .TechnicalWriter import TechnicalWriter
+from .CodeMonkey import CodeMonkey

--- a/pilot/helpers/agents/test_Architect.py
+++ b/pilot/helpers/agents/test_Architect.py
@@ -1,0 +1,35 @@
+import builtins
+import os
+from unittest.mock import patch
+from dotenv import load_dotenv
+from pilot.helpers.agents import Architect
+
+from pilot.helpers.test_Project import create_project
+load_dotenv()
+
+from main import get_custom_print
+
+
+class TestTechLead:
+    def setup_method(self):
+        builtins.print, ipc_client_instance = get_custom_print({})
+
+        name = 'TestArchitect'
+        self.project = create_project()
+        self.project.app_id = 'test-architect'
+        self.project.name = name
+
+
+        self.project.set_root_path(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                              '../../../workspace/TestArchitect')))
+
+    def test_architect_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+
+        model = 'some_model'
+        monkeypatch.setenv('ARCHITECT_MODEL_NAME', model)
+
+        # and a developer who will execute any task
+        agent = Architect(project)
+        assert agent.model == model

--- a/pilot/helpers/agents/test_CodeMonkey.py
+++ b/pilot/helpers/agents/test_CodeMonkey.py
@@ -28,7 +28,7 @@ class TestTechLead:
         project = create_project()
 
         model = 'some_model'
-        monkeypatch.setenv('ARCHITECT_MODEL_NAME', model)
+        monkeypatch.setenv('CODE_MONKEY_MODEL_NAME', model)
 
         # and a developer who will execute any task
         agent = CodeMonkey(project)

--- a/pilot/helpers/agents/test_CodeMonkey.py
+++ b/pilot/helpers/agents/test_CodeMonkey.py
@@ -1,0 +1,35 @@
+import builtins
+import os
+from unittest.mock import patch
+from dotenv import load_dotenv
+from pilot.helpers.agents import Architect, CodeMonkey
+
+from pilot.helpers.test_Project import create_project
+load_dotenv()
+
+from main import get_custom_print
+
+
+class TestTechLead:
+    def setup_method(self):
+        builtins.print, ipc_client_instance = get_custom_print({})
+
+        name = 'TestCodeMonkey'
+        self.project = create_project()
+        self.project.app_id = 'test-code-monkey'
+        self.project.name = name
+
+
+        self.project.set_root_path(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                              '../../../workspace/TestCodeMonkey')))
+
+    def test_code_monkey_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+
+        model = 'some_model'
+        monkeypatch.setenv('ARCHITECT_MODEL_NAME', model)
+
+        # and a developer who will execute any task
+        agent = CodeMonkey(project)
+        assert agent.model == model

--- a/pilot/helpers/agents/test_Developer.py
+++ b/pilot/helpers/agents/test_Developer.py
@@ -225,44 +225,13 @@ class TestDeveloper:
         assert mock_requests_post.call_count == 0
 
 
-    @patch('helpers.AgentConvo.save_development_step')
-    @patch('helpers.AgentConvo.create_gpt_chat_completion', return_value={'text': '{"tasks": [{"command": "ls -al"}]}'})
     def test_developer_model_override(self, monkeypatch):
         # Given any project
         project = create_project()
-        project.project_description = 'Test Project'
-        project.development_plan = [{
-            'description': 'Do stuff',
-            'user_review_goal': 'Do stuff',
-        }]
-        project.get_all_coded_files = lambda: []
-        project.current_step = 'test'
+
+        model = 'some_model'
+        monkeypatch.setenv('FULL_STACK_DEVELOPER_MODEL_NAME', model)
 
         # and a developer who will execute any task
-        developer = Developer(project)
-        developer.execute_task = MagicMock()
-        developer.execute_task.return_value = {'success': True}
-
-        # When
-        developer.implement_task(0, {'description': 'Do stuff'})
-
-        # Then we parse the response correctly and send list of steps to execute_task()
-        assert developer.execute_task.call_count == 1
-        assert developer.execute_task.call_args[0][1] == [{'command': 'ls -al'}]
-
-        # # Given any project
-        # project = create_project()
-        # project.project_description = 'Test Project'
-        # project.development_plan = [{
-        #     'description': 'Do stuff',
-        #     'user_review_goal': 'Do stuff',
-        # }]
-        # project.get_all_coded_files = lambda: []
-        # project.current_step = 'test'
-
-        # model = 'some_model'
-        # monkeypatch.setenv('FULL_STACK_DEVELOPER_MODEL_NAME', model)
-
-        # # and a developer who will execute any task
-        # developer = Developer(project)
-        # assert developer.modle == model
+        agent = Developer(project)
+        assert agent.model == model

--- a/pilot/helpers/agents/test_Developer.py
+++ b/pilot/helpers/agents/test_Developer.py
@@ -223,3 +223,46 @@ class TestDeveloper:
         # Then
         assert result == {'success': True}
         assert mock_requests_post.call_count == 0
+
+
+    @patch('helpers.AgentConvo.save_development_step')
+    @patch('helpers.AgentConvo.create_gpt_chat_completion', return_value={'text': '{"tasks": [{"command": "ls -al"}]}'})
+    def test_developer_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+        project.project_description = 'Test Project'
+        project.development_plan = [{
+            'description': 'Do stuff',
+            'user_review_goal': 'Do stuff',
+        }]
+        project.get_all_coded_files = lambda: []
+        project.current_step = 'test'
+
+        # and a developer who will execute any task
+        developer = Developer(project)
+        developer.execute_task = MagicMock()
+        developer.execute_task.return_value = {'success': True}
+
+        # When
+        developer.implement_task(0, {'description': 'Do stuff'})
+
+        # Then we parse the response correctly and send list of steps to execute_task()
+        assert developer.execute_task.call_count == 1
+        assert developer.execute_task.call_args[0][1] == [{'command': 'ls -al'}]
+
+        # # Given any project
+        # project = create_project()
+        # project.project_description = 'Test Project'
+        # project.development_plan = [{
+        #     'description': 'Do stuff',
+        #     'user_review_goal': 'Do stuff',
+        # }]
+        # project.get_all_coded_files = lambda: []
+        # project.current_step = 'test'
+
+        # model = 'some_model'
+        # monkeypatch.setenv('FULL_STACK_DEVELOPER_MODEL_NAME', model)
+
+        # # and a developer who will execute any task
+        # developer = Developer(project)
+        # assert developer.modle == model

--- a/pilot/helpers/agents/test_ProductOwner.py
+++ b/pilot/helpers/agents/test_ProductOwner.py
@@ -65,3 +65,14 @@ class TestProductOwner:
         assert 'EVERYTHING_CLEAR' not in summary
         assert 'neutral tone' not in summary
         assert 'clarification' not in summary
+
+    def test_product_owner_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+
+        model = 'some_model'
+        monkeypatch.setenv('PRODUCT_OWNER_MODEL_NAME', model)
+
+        # and a developer who will execute any task
+        agent = ProductOwner(project)
+        assert agent.model == model

--- a/pilot/helpers/agents/test_TechLead.py
+++ b/pilot/helpers/agents/test_TechLead.py
@@ -3,6 +3,8 @@ import os
 import pytest
 from unittest.mock import patch
 from dotenv import load_dotenv
+
+from pilot.helpers.test_Project import create_project
 load_dotenv()
 
 from main import get_custom_print
@@ -16,16 +18,13 @@ class TestTechLead:
     def setup_method(self):
         builtins.print, ipc_client_instance = get_custom_print({})
 
+
         name = 'TestTechLead'
-        self.project = Project({
-                'app_id': 'test-tech-lead',
-                'name': name,
-                'app_type': ''
-            },
-            name=name,
-            architecture=[],
-            user_stories=[]
-        )
+        self.project = create_project()
+        self.project.app_id = 'test-tech-lead'
+        self.project.name = name
+        self.project.architecture = []
+        self.project.user_stories = []
 
         self.project.set_root_path(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                                               '../../../workspace/TestTechLead')))
@@ -66,3 +65,14 @@ The development process will include the creation of user stories and tasks, bas
             assert development_plan is not None
             assert_non_empty_string(development_plan[0]['description'])
             assert_non_empty_string(development_plan[0]['user_review_goal'])
+
+    def test_tech_lead_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+
+        model = 'some_model'
+        monkeypatch.setenv('TECH_LEAD_MODEL_NAME', model)
+
+        # and a developer who will execute any task
+        agent = TechLead(project)
+        assert agent.model == model

--- a/pilot/helpers/agents/test_TechnicalWriter.py
+++ b/pilot/helpers/agents/test_TechnicalWriter.py
@@ -1,0 +1,35 @@
+import builtins
+import os
+from unittest.mock import patch
+from dotenv import load_dotenv
+from pilot.helpers.agents import TechnicalWriter
+
+from pilot.helpers.test_Project import create_project
+load_dotenv()
+
+from main import get_custom_print
+
+
+class TestTechLead:
+    def setup_method(self):
+        builtins.print, ipc_client_instance = get_custom_print({})
+
+        name = 'TestTechnicalWriter'
+        self.project = create_project()
+        self.project.app_id = 'test-technical-writer'
+        self.project.name = name
+
+
+        self.project.set_root_path(os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                              '../../../workspace/TestTechnicalWriter')))
+
+    def test_technical_writer_model_override(self, monkeypatch):
+        # Given any project
+        project = create_project()
+
+        model = 'some_model'
+        monkeypatch.setenv('TECHNICAL_WRITER_MODEL_NAME', model)
+
+        # and a developer who will execute any task
+        agent = TechnicalWriter(project)
+        assert agent.model == model

--- a/pilot/prompts/prompts.py
+++ b/pilot/prompts/prompts.py
@@ -73,7 +73,7 @@ def ask_user(project, question: str, require_some_input=True, hint: str = None, 
             return answer
 
 
-def get_additional_info_from_openai(project, messages):
+def get_additional_info_from_openai(project, messages, model):
     """
     Runs the conversation between Product Owner and LLM.
     Provides the user's initial description, LLM asks the user clarifying questions and user responds.
@@ -91,7 +91,7 @@ def get_additional_info_from_openai(project, messages):
         # Obtain clarifications using the OpenAI API
         # { 'text': new_code }
         try:
-            response = create_gpt_chat_completion(messages, 'additional_info', project)
+            response = create_gpt_chat_completion(messages, 'additional_info', project, model)
         except ApiError:
             response = None
 

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -78,7 +78,7 @@ def test_api_access(project) -> bool:
     endpoint = os.getenv('ENDPOINT')
     model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4')
     try:
-        response = create_gpt_chat_completion(messages, 'project_description', project)
+        response = create_gpt_chat_completion(messages, 'project_description', project, model)
         if response is None or response == {}:
             print(color_red("Error connecting to the API. Please check your API key/endpoint and try again."))
             logger.error(f"The request to {endpoint} model {model} API failed.")

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -76,7 +76,7 @@ def test_api_access(project) -> bool:
     ]
 
     endpoint = os.getenv('ENDPOINT')
-    model = os.getenv('MODEL_NAME', 'gpt-4')
+    model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4')
     try:
         response = create_gpt_chat_completion(messages, 'project_description', project)
         if response is None or response == {}:
@@ -89,8 +89,7 @@ def test_api_access(project) -> bool:
         logger.error(f"The request to {endpoint} model {model} API failed: {err}", exc_info=err)
         return False
 
-
-def create_gpt_chat_completion(messages: List[dict], req_type, project,
+def create_gpt_chat_completion(messages: List[dict], req_type, project, model:str,
                                function_calls: FunctionCallSet = None,
                                prompt_data: dict = None):
     """
@@ -111,8 +110,9 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
              {'function_calls': {'name': str, arguments: {...}}}
     """
 
+
     gpt_data = {
-        'model': os.getenv('MODEL_NAME', 'gpt-4'),
+        'model': model,
         'n': 1,
         'temperature': 1,
         'top_p': 1,
@@ -396,7 +396,7 @@ def stream_gpt_completion(data, req_type, project):
     # print(yellow("Stream response from OpenAI:"))
 
     # Configure for the selected ENDPOINT
-    model = os.getenv('MODEL_NAME', 'gpt-4')
+    model = os.getenv('DEFAULT_MODEL_NAME', 'gpt-4')
     endpoint = os.getenv('ENDPOINT')
 
     logger.info(f'> Request model: {model}')

--- a/pilot/utils/test_llm_connection.py
+++ b/pilot/utils/test_llm_connection.py
@@ -453,7 +453,7 @@ class TestLlmConnection:
     def test_chat_completion_Architect(self, endpoint, model, monkeypatch):
         # Given
         monkeypatch.setenv('ENDPOINT', endpoint)
-        monkeypatch.setenv('MODEL_NAME', model)
+        monkeypatch.setenv('DEFAULT_MODEL_NAME', model)
         project = Project({'app_id': 'test-app'})
 
         agent = Architect(project)
@@ -511,7 +511,7 @@ solution-oriented decision-making in areas where precise instructions were not p
     def test_chat_completion_TechLead(self, endpoint, model, monkeypatch):
         # Given
         monkeypatch.setenv('ENDPOINT', endpoint)
-        monkeypatch.setenv('MODEL_NAME', model)
+        monkeypatch.setenv('DEFAULT_MODEL_NAME', model)
         project = Project({'app_id': 'test-app'})
 
         agent = TechLead(project)

--- a/pilot/utils/test_llm_connection.py
+++ b/pilot/utils/test_llm_connection.py
@@ -487,7 +487,7 @@ solution-oriented decision-making in areas where precise instructions were not p
         function_calls = ARCHITECTURE
 
         # When
-        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls)
+        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls, model)
 
         # Then
         assert convo.messages[0]['content'].startswith('You are an experienced software architect')
@@ -543,7 +543,7 @@ The development process will include the creation of user stories and tasks, bas
 
         # with patch('utils.llm_connection.questionary', mock_questionary):
         # When
-        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls)
+        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls, model)
 
         # Then
         assert convo.messages[0]['content'].startswith('You are a tech lead in a software development agency')

--- a/pilot/utils/test_llm_connection.py
+++ b/pilot/utils/test_llm_connection.py
@@ -487,7 +487,7 @@ solution-oriented decision-making in areas where precise instructions were not p
         function_calls = ARCHITECTURE
 
         # When
-        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls, model)
+        response = create_gpt_chat_completion(convo.messages, '', project, model, function_calls=function_calls)
 
         # Then
         assert convo.messages[0]['content'].startswith('You are an experienced software architect')
@@ -543,7 +543,7 @@ The development process will include the creation of user stories and tasks, bas
 
         # with patch('utils.llm_connection.questionary', mock_questionary):
         # When
-        response = create_gpt_chat_completion(convo.messages, '', project, function_calls=function_calls, model)
+        response = create_gpt_chat_completion(convo.messages, '', project, model, function_calls=function_calls)
 
         # Then
         assert convo.messages[0]['content'].startswith('You are a tech lead in a software development agency')


### PR DESCRIPTION
In an effort to help pilot become more cost effective I wanted to try and have some tasks completed by other models, GPT 3.5 Turbo for coding as an example. 

This PR introduced new env vars 

```
# Override model for an agent 
#FULL_STACK_DEVELOPER_MODEL_NAME=gpt-4-turbo-preview
#CODE_MONKEY_MODEL_NAME=gpt-4-turbo-preview
#ARCHITECT_MODEL_NAME=gpt-4-turbo-preview
#PRODUCT_OWNER_MODEL_NAME=gpt-4-turbo-preview
#TECH_LEAD_MODEL_NAME=gpt-4-turbo-preview
#DEV_OPS_MODEL_NAME=gpt-4-turbo-preview
#TECHNICAL_WRITER_MODEL_NAME=gpt-4-turbo-preview
DEFAULT_MODEL_NAME=gpt-4-turbo-preview
```

I have not tested yet with the OpenAI API, wanted to get feed back before doing this.

On a side note I found some of the agent object relationships a bit all over the place and wanted to know what your plan is for this area. I think it would benefit from making interactions more standard taking advantage of polymorphism. as an example moving logic in the AgentConvo class into the Agent base class. Would love to know your thoughts.

Thanks
