### PR TITLE
Don't encourage developer to refactor files.

### DIFF
--- a/pilot/const/function_calls.py
+++ b/pilot/const/function_calls.py
@@ -109,34 +109,6 @@ def step_save_file_definition():
     }
 
 
-def step_delete_file_definition():
-    return {
-        "type": "object",
-        "properties": {
-            "type": {
-                "const": "delete_file",
-                "description": dev_step_type_description()
-            },
-            "delete_file": {
-                "type": "object",
-                "description": "A file that should be deleted. This should only be used for existing files that should get removed from the project.",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Name of the existing file that needs to be deleted."
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Full path of the file with the file name that needs to be deleted."
-                    }
-                },
-                "required": ["name", "path"]
-            }
-        },
-        "required": ["type", "delete_file"]
-    }
-
-
 def step_human_intervention_definition():
     return {
         "type": "object",
@@ -303,7 +275,6 @@ IMPLEMENT_TASK = {
                             "oneOf": [
                                 step_command_definition(),
                                 step_save_file_definition(),
-                                step_delete_file_definition(),
                                 step_human_intervention_definition(),
                             ]
                         }

--- a/pilot/prompts/components/file_size_limit.prompt
+++ b/pilot/prompts/components/file_size_limit.prompt
@@ -1,2 +1,2 @@
 **IMPORTANT**
-When you think about in which file should the new code go to, always try to make files as small as possible and put code in more smaller files rather than in one big file. Whenever a file becomes too large (more than 100 lines of code) split it into smaller files.
+When you think about in which file should the new code go to, always try to make files as small as possible and put code in more smaller files rather than in one big file.

--- a/pilot/prompts/components/steps_list.prompt
+++ b/pilot/prompts/components/steps_list.prompt
@@ -2,7 +2,6 @@
 The current task has been split into multiple steps, and each step is one of the following:
 * `command` - command to run
 * `save_file` -  create or update a file
-* `delete_file` - delete a file that's no longer needed
 * `human_intervention` - if the human needs to do something
 
 {% if step_index > 0 %}Here is the list of steps that have been executed:

--- a/pilot/prompts/development/parse_task.prompt
+++ b/pilot/prompts/development/parse_task.prompt
@@ -4,7 +4,6 @@ Each step can be either:
 
 * `command` - command to run (must be able to run on a {{ os }} machine, assume current working directory is project root folder)
 * `save_file` - create or update ONE file
-* `delete_file` - delete a file that is no longer used
 * `human_intervention` - if you need the human to do something, use this type of step and explain in details what you want the human to do. NEVER use `human_intervention` for testing, as testing will be done separately by a dedicated QA after all the steps are done.
 
 **IMPORTANT**: In `code_change_description` field of `save_file` step, you must provide empty string. If multiple changes are required for same file, you must provide single `save_file` step for each file.
@@ -30,13 +29,6 @@ Examples:
         "code_change_description": "",
       },
     },
-    {
-      "type": "delete_file",
-      "delete_file": {
-        "name": "some_old_unused_file.js",
-        "path": "some/path/to/some_old_unused_file.js",
-      }
-    }
     {
       "type": "command",
       "command": {

--- a/pilot/prompts/system_messages/full_stack_developer.prompt
+++ b/pilot/prompts/system_messages/full_stack_developer.prompt
@@ -1,5 +1,5 @@
 You are an expert full stack software developer who works in a software development agency.
 
-You write modular, well-organized code split across files that are not too big (max 100 lines of code per file), so that the codebase is maintainable. Your code is clean, readable, production-level quality, and has proper error handling and logging.
+You write modular, well-organized code split across files that are not too big, so that the codebase is maintainable. Your code is clean, readable, production-level quality, and has proper error handling and logging.
 
 Your job is to implement tasks that your tech lead assigns you. Each task has a description of what needs to be implemented.


### PR DESCRIPTION
Asking developer to refactor code when it notices some files are too large doesn't always work, but when it does, the results are usually bad: code duplication that creates problems later.

Since this will be done in a separate phase, it's better not to try and actively encourage developer to do it while it's doing other things. It's still good to try and keep the files small (eg. by putting new functionality in new files), but it's less risky if we don't ask it to split files.

Relatedly, this also removes the step type `delete_file` since it's been incorrectly triggered. The handler code is left into avoid crashing if the task list already has it.