### PR TITLE
fix jinja paths on windows

### DIFF
--- a/pilot/templates/render.py
+++ b/pilot/templates/render.py
@@ -54,6 +54,9 @@ class Renderer:
         Returns the resulting string
         """
 
+        # Jinja2 always uses /, even on Windows
+        template = template.replace('\\', '/')
+
         tpl_object = self.jinja_env.get_template(template)
         return tpl_object.render(context)
 


### PR DESCRIPTION
Jinja always uses `/` for template paths, even on Windows: https://github.com/pallets/jinja/issues/767#issuecomment-327848886

