### PR TITLE
File modification reviewer can now send back the changes for rework

### DIFF
--- a/pilot/const/function_calls.py
+++ b/pilot/const/function_calls.py
@@ -476,7 +476,7 @@ GET_DOCUMENTATION_FILE = {
 REVIEW_CHANGES = {
     'definitions': [{
         'name': 'review_diff',
-        'description': 'Review a unified diff and select hunks to apply.',
+        'description': 'Review a unified diff and select hunks to apply or rework.',
         'parameters': {
             "type": "object",
             "properties": {
@@ -491,12 +491,12 @@ REVIEW_CHANGES = {
                             },
                             "reason": {
                                 "type": "string",
-                                "description": "Reason for applying or ignoring this hunk."
+                                "description": "Reason for applying or ignoring this hunk, or for asking for it to be reworked."
                             },
                             "decision": {
                                 "type": "string",
-                                "enum": ["apply", "ignore"],
-                                "description": "Whether to apply this hunk (if it's a valid change) or ignore it."
+                                "enum": ["apply", "ignore", "rework"],
+                                "description": "Whether to apply this hunk (if it's a valid change with no problems), rework (a valid change but does something incorrectly), or ignore it (unwanted change)."
                             }
                         },
                         "required": ["number", "reason", "decision"],

--- a/pilot/prompts/development/review_changes.prompt
+++ b/pilot/prompts/development/review_changes.prompt
@@ -15,11 +15,16 @@ Here is the diff of the changes:
 
 As you can see, there {% if hunks|length == 1 %}is only one hunk in this diff, and it{% else %}are {{hunks|length}} hunks in this diff, and each{% endif %} starts with the `@@` header line.
 
-Think carefully about the instructions and review the proposed changes. For each hunk of change, provide a detailed rationale, and decide whether it should be applied or should be ignored (for example if it is a code deletion or change that wasn't asked for). Finally, if the changes miss something that was in the instructions, mention that. Keep in mind you're just reviewing one file, `{{ file_name }}`. You don't need to consider if other files are created, dependent packages installed, etc. Focus only on reviewing the changes in this file based on the instructions in the previous message.
+Think carefully about the instructions and review the proposed changes. For each hunk of change, provide a detailed rationale, and decide whether it should be:
+* applied - if the change is correct
+* ignored - for example if it is a code deletion or change that wasn't asked for
+* reworked - if the change does something correctly but also makes a serious mistake, in which case both applying and ignoring the entire hunk would be incorrect
 
-Note that the developer may add, modify or delete logging (including `gpt_pilot_debugging_log`) or error handling that's not explicitly asked for, but is a part of good development practice. Unless these logging and error handling additions break something, you should not ignore those changes. Base your decision only on functional changes - comments or logging are less important.
+Finally, if the changes miss something that was in the instructions, mention that. Keep in mind you're just reviewing one file, `{{ file_name }}`. You don't need to consider if other files are created, dependent packages installed, etc. Focus only on reviewing the changes in this file based on the instructions in the previous message.
 
-Here is an example output if 3 of 4 hunks in the change should be applied and one of them should be ignored, and no other changes are needed:
+Note that the developer may add, modify or delete logging (including `gpt_pilot_debugging_log`) or error handling that's not explicitly asked for, but is a part of good development practice. Unless these logging and error handling additions break something, your decision to apply, ignore or rework the hunk should not be based on this. Base your decision only on functional changes - comments or logging are less important. Importantly, don't ask for a rework just because of logging or error handling changes. Also, take into account this is a junior developer and while the approach they take may not be the best practice, if it's not *wrong*, let it pass. Ask for rework only if the change is clearly bad and would break something.
+
+Here is an example output if 2 of 4 hunks in the change should be applied, one of them should be ignored, one should be reworked, and no other changes are needed:
 ```
 {
     "hunks": [
@@ -35,13 +40,13 @@ Here is an example output if 3 of 4 hunks in the change should be applied and on
         },
         {
             "number": 3,
-            "reason": "This hunk accidentally deletes important code",
+            "reason": "This hunk accidentally deletes important code without any useful change",
             "decision": "ignore"
         },
         {
             "number": 4,
-            "reason": "Explanation why the fourth hunk should be included in the change",
-            "decision": "apply"
+            "reason": "This hunk does something correctly but also does something really wrong. It would be incorrect to either apply or ignore it fully, so it should be reworked.",
+            "decision": "rework"
         },
     ],
     "review_notes": "General review notes, if something is missing from the change you can comment about it here"


### PR DESCRIPTION
There's a fine line here, as we don't want to rework changes that in theory could be better or more aligned with overall best practices. If we make the reviewer too aggressive, it will only make more rework demands, cost more and waste time.

Example where the reviewer doesn't ask for a rework for a trivial unimportant nitpick:
```json
{
    "hunks": [
        {
            "number": 1,
            "reason": "The added logging statement provides additional debug information which is a good practice, especially when dealing with authentication and form validation processes. However, the instructions did not specifically ask for logging to be added or modified. Given that this addition does not negatively impact the functionality and aligns with good development practices, it can be applied.",
            "decision": "apply"
        }
    ],
    "review_notes": "The change meets the initial request for ensuring that feedback is provided to the user when passwords do not match or are empty, through the use of flash messages. However, the instructions also mentioned ensuring the display of these flash messages in the profile.ejs view which is not covered in the diff provided. This review focuses solely on the authRoutes.js file as per the task instructions."
}
```

Example where reviewer rejects all the changes and we shouldn't ask to rework these:
```json
{
    "hunks": [
        {
            "number": 1,
            "reason": "The change simply removes a comment that was likely used for development clarity. Removing the comment doesn't affect the functionality of the code. However, the comment could be useful for future reference to understand why the userRoutes were added in the specific order.",
            "decision": "ignore"
        },
        {
            "number": 2,
            "reason": "This hunk also removes a comment without making any functional changes. Similar to the first hunk, the removal of this comment does not affect the application's functionality but could diminish code clarity for future development.",
            "decision": "ignore"
        }
    ],
    "review_notes": "Both changes made in the diff are comment removals that do not impact the functional aspect of the code. However, it's important to consider maintaining comments that provide clarity on the code structure or the order of middleware/routes, especially in a collaborative environment. No additional changes are required since the functional implementation aligns with the task requirements."
}
```
