### PR TITLE
fix gathering and printing stats 

### DIFF
--- a/pilot/helpers/AgentConvo.py
+++ b/pilot/helpers/AgentConvo.py
@@ -104,7 +104,7 @@ class AgentConvo:
             self.log_message(message_content)
 
         if self.agent.project.check_ipc():
-            telemetry.send_project_stats()
+            telemetry.output_project_stats()
         return response
 
     def format_message_content(self, response, function_calls):

--- a/pilot/test/utils/test_telemetry.py
+++ b/pilot/test/utils/test_telemetry.py
@@ -123,15 +123,7 @@ def test_telemetry_setup_enable(mock_uuid4, mock_settings):
 
 
 @patch("utils.telemetry.settings")
-def test_set_ignores_data_if_disabled(mock_settings):
-    mock_settings.telemetry = {"id": "existing-id", "enabled": False}
-    telemetry = Telemetry()
-    telemetry.set("model", "fake-model")
-    assert telemetry.data.get("model") != "fake-model"
-
-
-@patch("utils.telemetry.settings")
-def test_set_updates_data_if_enabled(mock_settings):
+def test_set_updates_data(mock_settings):
     mock_settings.telemetry = {
         "id": "test-id",
         "endpoint": "test-endpoint",
@@ -167,14 +159,6 @@ def test_inc_increments_known_data_field(mock_settings):
 
 
 @patch("utils.telemetry.settings")
-def test_inc_does_not_increment_when_disabled(mock_settings):
-    mock_settings.telemetry = {"id": "existing-id", "enabled": False}
-    telemetry = Telemetry()
-    telemetry.inc("num_llm_requests", 42)
-    assert telemetry.data["num_llm_requests"] == 0
-
-
-@patch("utils.telemetry.settings")
 def test_inc_ignores_unknown_data_field(mock_settings):
     mock_settings.telemetry = {
         "id": "test-id",
@@ -184,14 +168,6 @@ def test_inc_ignores_unknown_data_field(mock_settings):
     telemetry = Telemetry()
     telemetry.inc("unknown_field")
     assert "unknown_field" not in telemetry.data
-
-
-@patch("utils.telemetry.settings")
-def test_start_with_telemetry_disabled(mock_settings):
-    mock_settings.telemetry = {"id": "existing-id", "enabled": False}
-    telemetry = Telemetry()
-    telemetry.start()
-    assert telemetry.start_time is None
 
 
 @patch("utils.telemetry.time")

--- a/pilot/utils/telemetry.py
+++ b/pilot/utils/telemetry.py
@@ -184,9 +184,6 @@ class Telemetry:
 
         Note: only known data fields may be set, see `Telemetry.clear_data()` for a list.
         """
-        if not self.enabled:
-            return
-
         if name not in self.data:
             log.error(
                 f"Telemetry.record(): ignoring unknown telemetry data field: {name}"
@@ -204,9 +201,6 @@ class Telemetry:
 
         Note: only known data fields may be increased, see `Telemetry.clear_data()` for a list.
         """
-        if not self.enabled:
-            return
-
         if name not in self.data:
             log.error(
                 f"Telemetry.increase(): ignoring unknown telemetry data field: {name}"
@@ -219,9 +213,6 @@ class Telemetry:
         """
         Record start of application creation process.
         """
-        if not self.enabled:
-            return
-
         self.start_time = time.time()
         self.end_time = None
 
@@ -229,9 +220,6 @@ class Telemetry:
         """
         Record end of application creation process.
         """
-        if not self.enabled:
-            return
-
         if self.start_time is None:
             log.error("Telemetry.stop(): cannot stop telemetry, it was never started")
             return
@@ -302,9 +290,6 @@ class Telemetry:
         :param elapsed_time: time elapsed for the request
         :param is_error: whether the request resulted in an error
         """
-        if not self.enabled:
-            return
-
         self.inc("num_llm_requests")
 
         if is_error:
@@ -377,14 +362,12 @@ class Telemetry:
                 f"Telemetry.send(): failed to send telemetry data: {e}", exc_info=True
             )
 
-    def send_project_stats(self):
+    def output_project_stats(self):
         """
-        Send project statistics to the extension.
+        Output project statistics to the extension.
 
-        Note: this method does not clear any telemetry data.
+        This does not send the stats to any server.
         """
-        if not self.enabled:
-            return
 
         print({
             "num_lines": self.data["num_lines"],


### PR DESCRIPTION
This is needed even when not sending them to the serrver, used for extension to show stats in the UI:

![Screenshot from 2024-03-06 21-34-02](https://github.com/Pythagora-io/gpt-pilot/assets/3362/fc6394ec-fc05-49c4-9fda-4709d14eb0c6)
