### PR TITLE
Issue #727 added the missing OPENAI_ENDPOINT env entry in the Docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
             # OPENAI/AZURE/OPENROUTER
             - ENDPOINT=OPENAI
             - OPENAI_API_KEY=
+            - OPENAI_ENDPOINT=
             # - AZURE_API_KEY=
             # - AZURE_ENDPOINT=
             # - OPENROUTER_API_KEY=


### PR DESCRIPTION
---

### Summary

This pull request resolves **Issue #727** by adding the missing `OPENAI_ENDPOINT` environment entry in the Docker compose file.

### Changes Made

- Added the `OPENAI_ENDPOINT` environment entry to the Docker compose file.

### Related Issues

- Fixes: #727

--- 