### PR TITLE
give clear instructions how to finish setting up incomplete venv

### DIFF
--- a/pilot/main.py
+++ b/pilot/main.py
@@ -9,7 +9,18 @@ import traceback
 try:
     from dotenv import load_dotenv
 except ImportError:
-    raise RuntimeError('Python environment for GPT Pilot is not completely set up: required package "python-dotenv" is missing.') from None
+    gpt_pilot_root = os.path.dirname(os.path.dirname(__file__))
+    venv_path = os.path.join(gpt_pilot_root, 'pilot-env')
+    requirements_path = os.path.join(gpt_pilot_root, 'requirements.txt')
+    if sys.prefix == sys.base_prefix:
+        venv_python_path = os.path.join(venv_path, 'scripts' if sys.platform == 'win32' else 'bin', 'python')
+        print('Python environment for GPT Pilot is not set up.')
+        print(f'Please create Python virtual environment: {sys.executable} -m venv {venv_path}')
+        print(f'Then install the required dependencies with: {venv_python_path} -m pip install -r {requirements_path}')
+    else:
+        print('Python environment for GPT Pilot is not completely set up.')
+        print(f'Please run `{sys.executable} -m pip install -r {requirements_path}` to finish Python setup, and rerun GPT Pilot.')
+    sys.exit(-1)
 
 load_dotenv()
 


### PR DESCRIPTION
If we know Python packages are missing, tell the user exactly how to fix it:

### Linux

No environment yet:

```
$ python3 main.py
Python environment for GPT Pilot is not set up.
Please create Python virtual environment: /usr/bin/python3 -m venv /home/senko/Projects/Pythagora/gpt-pilot/pilot-env
Then install the required dependencies with: /home/senko/Projects/Pythagora/gpt-pilot/pilot-env/bin/python -m pip install -r /home/senko/Projects/Pythagora/gpt-pilot/requirements.txt

$ /usr/bin/python3 -m venv /home/senko/Projects/Pythagora/gpt-pilot/pilot-test-env

]$ /home/senko/Projects/Pythagora/gpt-pilot/pilot-test-env/bin/python -m pip install -r /home/senko/Projects/Pythagora/gpt-pilot/requirements.txt
[...omitted for clarity...]
Successfully installed Jinja2-3.1.2 MarkupSafe-2.1.3 attrs-23.2.0 blessed-1.20.0 certifi-2023.7.22 charset-normalizer-3.3.2 colorama-0.4.6 distro-1.8.0 idna-3.4 iniconfig-2.0.0 jsonschema-4.19.2 jsonschema-specifications-2023.12.1 packaging-24.0 peewee-3.16.3 pluggy-1.4.0 prompt-toolkit-3.0.40 psutil-5.9.6 psycopg2-binary-2.9.9 pytest-7.4.2 python-dotenv-1.0.0 python-editor-1.0.4 pyyaml-6.0.1 questionary-1.10.0 readchar-4.0.5 referencing-0.33.0 regex-2023.10.3 requests-2.31.0 rpds-py-0.18.0 six-1.16.0 termcolor-2.3.0 tiktoken-0.5.2 urllib3-1.26.7 wcwidth-0.2.8 yaspin-2.5.0

$ python main.py --get-created-apps-with-steps
----------------------------------------------------------------------------------------
app_id                                step                 dev_step  name
----------------------------------------------------------------------------------------
```

Incomplete environment:

```
$ python3 -m venv /tmp/test-venv

$ source /tmp/test-venv/bin/activate

$ python main.py 
Python environment for GPT Pilot is not completely set up.
Please run `/tmp/test-venv/bin/python -m pip install -r /home/senko/Projects/Pythagora/gpt-pilot/requirements.txt` to finish Python setup, and rerun GPT Pilot.

$ /tmp/test-venv/bin/python -m pip install -r /home/senko/Projects/Pythagora/gpt-pilot/requirements.txt 
[...omitted for clarity...]
Successfully installed Jinja2-3.1.2 MarkupSafe-2.1.3 attrs-23.2.0 blessed-1.20.0 certifi-2023.7.22 charset-normalizer-3.3.2 colorama-0.4.6 distro-1.8.0 idna-3.4 iniconfig-2.0.0 jsonschema-4.19.2 jsonschema-specifications-2023.12.1 packaging-24.0 peewee-3.16.3 pluggy-1.4.0 prompt-toolkit-3.0.40 psutil-5.9.6 psycopg2-binary-2.9.9 pytest-7.4.2 python-dotenv-1.0.0 python-editor-1.0.4 pyyaml-6.0.1 questionary-1.10.0 readchar-4.0.5 referencing-0.33.0 regex-2023.10.3 requests-2.31.0 rpds-py-0.18.0 six-1.16.0 termcolor-2.3.0 tiktoken-0.5.2 urllib3-1.26.7 wcwidth-0.2.8 yaspin-2.5.0

$ python main.py --get-created-apps-with-steps
----------------------------------------------------------------------------------------
app_id                                step                 dev_step  name
----------------------------------------------------------------------------------------
```

### Windows

![Screenshot from 2024-03-15 18-20-18](https://github.com/Pythagora-io/gpt-pilot/assets/3362/6a513b60-1951-4508-8730-6f96a026ef68)


