### PR TITLE
Experimental support for Anthropic Claude API

### DIFF
--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -1,4 +1,4 @@
-# OPENAI or AZURE or OPENROUTER
+# OPENAI or AZURE or OPENROUTER (ignored for Anthropic)
 ENDPOINT=OPENAI
 
 # OPENAI_ENDPOINT=https://api.openai.com/v1/chat/completions
@@ -10,8 +10,15 @@ AZURE_ENDPOINT=
 
 OPENROUTER_API_KEY=
 
+ANTHROPIC_API_KEY=
+
+# You only need to set this if not using Anthropic API directly (eg. via proxy or AWS Bedrock)
+ANTHROPIC_ENDPOINT=
+
 # In case of Azure/OpenRouter endpoint, change this to your deployed model name
 MODEL_NAME=gpt-4-turbo-preview
+# In case of Anthropic, use "anthropic/" + the model name, example for Claude 3 Opus
+# MODEL_NAME=anthropic/claude-3-opus-20240229
 MAX_TOKENS=8192
 
 # Folders which shouldn't be tracked in workspace (useful to ignore folders created by compiler)

--- a/pilot/main.py
+++ b/pilot/main.py
@@ -66,6 +66,8 @@ if __name__ == "__main__":
 
         if '--api-key' in args:
             os.environ["OPENAI_API_KEY"] = args['--api-key']
+        if '--model-name' in args:
+            os.environ['MODEL_NAME'] = args['--model-name']
         if '--api-endpoint' in args:
             os.environ["OPENAI_ENDPOINT"] = args['--api-endpoint']
 

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -109,8 +109,9 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
              {'function_calls': {'name': str, arguments: {...}}}
     """
 
+    model_name = os.getenv('MODEL_NAME', 'gpt-4')
     gpt_data = {
-        'model': os.getenv('MODEL_NAME', 'gpt-4'),
+        'model': model_name,
         'n': 1,
         'temperature': temperature,
         'top_p': 1,
@@ -133,8 +134,18 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
     if prompt_data is not None and function_call_message is not None:
         prompt_data['function_call_message'] = function_call_message
 
+    if '/' in model_name:
+        model_provider, model_name = model_name.split('/', 1)
+    else:
+        model_provider = 'openai'
+
     try:
-        response = stream_gpt_completion(gpt_data, req_type, project)
+        if model_provider == 'anthropic':
+            if not os.getenv('ANTHROPIC_API_KEY'):
+                os.environ['ANTHROPIC_API_KEY'] = os.getenv('OPENAI_API_KEY')
+            response = stream_anthropic(messages, function_call_message, gpt_data, model_name)
+        else:
+            response = stream_gpt_completion(gpt_data, req_type, project)
 
         # Remove JSON schema and any added retry messages
         while len(messages) > messages_length:
@@ -143,7 +154,7 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
     except TokenLimitError as e:
         raise e
     except Exception as e:
-        logger.error(f'The request to {os.getenv("ENDPOINT")} API failed: %s', e)
+        logger.error(f'The request to {os.getenv("ENDPOINT")} API for {model_provider}/{model_name} failed: %s', e, exc_info=True)
         print(color_red(f'The request to {os.getenv("ENDPOINT")} API failed with error: {e}. Please try again later.'))
         if isinstance(e, ApiError):
             raise e
@@ -588,3 +599,48 @@ def postprocessing(gpt_response: str, req_type) -> str:
 
 def load_data_to_json(string):
     return json.loads(fix_json(string))
+
+
+
+def stream_anthropic(messages, function_call_message, gpt_data, model_name = "claude-3-sonnet-20240229"):
+    try:
+        import anthropic
+    except ImportError as err:
+        raise RuntimeError("The 'anthropic' package is required to use the Anthropic Claude LLM.") from err
+
+    client = anthropic.Anthropic(
+        base_url=os.getenv('ANTHROPIC_ENDPOINT'),
+    )
+
+    claude_system = "You are a software development AI assistant."
+    claude_messages = messages
+    if messages[0]["role"] == "system":
+        claude_system = messages[0]["content"]
+        claude_messages = messages[1:]
+
+    if len(claude_messages):
+        cm2 = [claude_messages[0]]
+        for i in range(1, len(claude_messages)):
+            if cm2[-1]["role"] == claude_messages[i]["role"]:
+                cm2[-1]["content"] += "\n\n" + claude_messages[i]["content"]
+            else:
+                cm2.append(claude_messages[i])
+        claude_messages = cm2
+
+    response = ""
+    with client.messages.stream(
+        model=model_name,
+        max_tokens=4096,
+        temperature=0.5,
+        system=claude_system,
+        messages=claude_messages,
+    ) as stream:
+        for chunk in stream.text_stream:
+            print(chunk, type='stream', end='', flush=True)
+            response += chunk
+
+    if function_call_message is not None:
+        response = clean_json_response(response)
+        assert_json_schema(response, gpt_data["functions"])
+
+    return {"text": response}

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ tiktoken==0.5.2
 urllib3==1.26.7
 wcwidth==0.2.8
 yaspin==2.5.0
+anthropic==0.19.1


### PR DESCRIPTION
This adds support for Anthropic Claude via its new conversational API, using Anthropic Python SDK.

To enable the support, modify `.env` to add:
```
ANTHROPIC_API_KEY="sk-ant-api03-yourkey"
MODEL_NAME=anthropic/claude-3-opus-20240229
```

If proxying the Anthropic API through something else (must support its new conversational API), you can also set `ANTHROPIC_ENDPOINT`.

Sonnet and/or Haiku can also be used (Haiku probably won't work well for all the agents tho).

Also supports `--model-name` setting to override the model name at runtime (to be used by the Pythagora extension eventually).

## Tests

I added ANTHROPIC and OPENAI prints to distinguish between the two in the screenshots.

With this merged, default (empty) `.env`:

![Screenshot from 2024-03-19 16-31-31](https://github.com/Pythagora-io/gpt-pilot/assets/3362/9894ea32-f8f8-405e-970f-033697fafbe7)

With this merged, `.env` with OpenAI keys:

![Screenshot from 2024-03-19 16-33-08](https://github.com/Pythagora-io/gpt-pilot/assets/3362/5279717b-729f-41cf-862f-8bf37ae392d2)

With this merged and Anthropic keys in `.env`:

![Screenshot from 2024-03-19 16-34-54](https://github.com/Pythagora-io/gpt-pilot/assets/3362/74f25382-b83a-428f-86da-01215f0cef5b)



