### PR TITLE
Don't ignore openrouter settings if using anthropic with openrouter

### DIFF
--- a/pilot/.env.example
+++ b/pilot/.env.example
@@ -10,10 +10,12 @@ AZURE_ENDPOINT=
 
 OPENROUTER_API_KEY=
 
+# Set this to use Anthropic API directly
+# If using via OpenRouter, OPENROUTER_API_KEY should be set instead
 ANTHROPIC_API_KEY=
 
 # You only need to set this if not using Anthropic API directly (eg. via proxy or AWS Bedrock)
-ANTHROPIC_ENDPOINT=
+# ANTHROPIC_ENDPOINT=
 
 # In case of Azure/OpenRouter endpoint, change this to your deployed model name
 MODEL_NAME=gpt-4-turbo-preview

--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -140,7 +140,7 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
         model_provider = 'openai'
 
     try:
-        if model_provider == 'anthropic':
+        if model_provider == 'anthropic' and os.getenv('ENDPOINT') != 'OPENROUTER':
             if not os.getenv('ANTHROPIC_API_KEY'):
                 os.environ['ANTHROPIC_API_KEY'] = os.getenv('OPENAI_API_KEY')
             response = stream_anthropic(messages, function_call_message, gpt_data, model_name)
@@ -609,7 +609,7 @@ def stream_anthropic(messages, function_call_message, gpt_data, model_name = "cl
         raise RuntimeError("The 'anthropic' package is required to use the Anthropic Claude LLM.") from err
 
     client = anthropic.Anthropic(
-        base_url=os.getenv('ANTHROPIC_ENDPOINT'),
+        base_url=os.getenv('ANTHROPIC_ENDPOINT') or None,
     )
 
     claude_system = "You are a software development AI assistant."


### PR DESCRIPTION
The Anthropic API support accidentially broke Anthropic via OpenRouter. This fixes it and also documents the example env a bit better.
