### PR TITLE
Don't recurse and load related models which we don't need

### DIFF
--- a/pilot/database/database.py
+++ b/pilot/database/database.py
@@ -120,7 +120,7 @@ def get_all_app_development_steps(app_id, last_step=None, loading_steps_only=Fal
                             (DevelopmentSteps.prompt_path.contains('feature_plan')) |
                             (DevelopmentSteps.prompt_path.contains('feature_summary')))
 
-    return [model_to_dict(dev_step) for dev_step in query]
+    return [model_to_dict(dev_step, recurse=False) for dev_step in query]
 
 
 def get_last_development_step(app_id, last_step=None):
@@ -132,7 +132,7 @@ def get_last_development_step(app_id, last_step=None):
     last_dev_step = last_dev_step_query.order_by(DevelopmentSteps.id.desc()).first()
 
     # If a step is found, convert it to a dictionary, otherwise return None
-    return model_to_dict(last_dev_step) if last_dev_step else None
+    return model_to_dict(last_dev_step, recurse=False) if last_dev_step else None
 
 
 def save_user(user_id, email, password):

--- a/pilot/helpers/agents/CodeMonkey.py
+++ b/pilot/helpers/agents/CodeMonkey.py
@@ -14,7 +14,7 @@ from utils.exit import trace_code_event
 from utils.telemetry import telemetry
 
 # Constant for indicating missing new line at the end of a file in a unified diff
-NO_EOL = "\ No newline at end of file"
+NO_EOL = "\\ No newline at end of file"
 
 # Regular expression pattern for matching hunk headers
 PATCH_HEADER_PATTERN = re.compile(r"^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@")


### PR DESCRIPTION
Improve loading time and avoid crashes on gaps with this one simple trick.

Before (broken db):
```
$ time python main.py --get-created-apps-with-steps 

---------- GPT PILOT EXITING WITH ERROR ----------
Traceback (most recent call last):
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 7136, in get
    return clone.execute(database)[0]
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 4486, in __getitem__
    return self.row_cache[item]
           ~~~~~~~~~~~~~~^^^^^^
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot/main.py", line 87, in <module>
    x = repr(get_created_apps_with_steps())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot/database/database.py", line 97, in get_created_apps_with_steps
    last_step = get_last_development_step(app['id'])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot/database/database.py", line 135, in get_last_development_step
    return model_to_dict(last_dev_step) if last_dev_step else None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/playhouse/shortcuts.py", line 82, in model_to_dict
    rel_obj = getattr(model, field.name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 4633, in __get__
    return self.get_rel_instance(instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 4624, in get_rel_instance
    obj = self.rel_model.get(self.field.rel_field == value)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 6688, in get
    return sq.get()
           ^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/pilot-env/lib/python3.11/site-packages/peewee.py", line 7139, in get
    raise self.model.DoesNotExist('%s instance matching query does '
database.models.development_steps.DevelopmentStepsDoesNotExist: <Model: DevelopmentSteps> instance matching query does not exist:
SQL: SELECT "t1"."id", "t1"."created_at", "t1"."updated_at", "t1"."app_id", "t1"."prompt_path", "t1"."llm_req_num", "t1"."token_limit_exception_raised", "t1"."messages", "t1"."llm_response", "t1"."prompt_data", "t1"."previous_step", "t1"."high_level_step" FROM "development_steps" AS "t1" WHERE ("t1"."id" = ?) LIMIT ? OFFSET ?
Params: [3803, 1, 0]
--------------------------------------------------

real	0m1.405s
user	0m1.237s
sys	0m0.168s
```

Before (manually fixed db):
```
$ time python main.py --get-created-apps-with-steps 
----------------------------------------------------------------------------------------
app_id                                step                 dev_step  name
----------------------------------------------------------------------------------------
edffcae1-b951-40c2-afb8-845e0dfb957b: coding                     49  App1
81aa749d-7d05-4155-ae3b-4471c6abbaba: coding                    3695  App2
6857bb76-44a2-46f9-8414-ab01b5481a35: project_description            App3

real	0m2.294s
user	0m2.132s
sys	0m0.160s
```


After (broken db):
```
$ time python main.py --get-created-apps-with-steps 
----------------------------------------------------------------------------------------
app_id                                step                 dev_step  name
----------------------------------------------------------------------------------------
edffcae1-b951-40c2-afb8-845e0dfb957b: coding                     49  App1
81aa749d-7d05-4155-ae3b-4471c6abbaba: coding                    3696  App2
6857bb76-44a2-46f9-8414-ab01b5481a35: project_description            App3

real	0m1.194s
user	0m1.053s
sys	0m0.141s
```
