### PR TITLE
Improve code filtering for the LLMs that are not fully following instructions

### DIFF
--- a/pilot/helpers/agents/CodeMonkey.py
+++ b/pilot/helpers/agents/CodeMonkey.py
@@ -178,12 +178,13 @@ class CodeMonkey(Agent):
     def remove_backticks(content: str) -> str:
         """
         Remove optional backticks from the beginning and end of the content.
+        Remove non-necessary explanation from LLM before or after the code.
 
         :param content: content to remove backticks from
         :return: content without backticks
         """
-        start_pattern = re.compile(r"^\s*```([a-z0-9]+)?\n")
-        end_pattern = re.compile(r"\n```\s*$")
+        start_pattern = re.compile(r"^.*?```([a-z0-9]+)?\n")
+        end_pattern = re.compile(r"\n```.*?$")
         content = start_pattern.sub("", content)
         content = end_pattern.sub("", content)
         return content


### PR DESCRIPTION
I see a lot of issues like unnecessary explanation from LLM when the instructions are clearly asking to not give anything else but code, for example:

> Here is the updated version of the public/js/leaderboard.js file with the requested changes:
> 
> \`\`\`
> export function updateLeaderboard(players) {
>     const leaderboardDiv = document.getElementById('leaderboard');
>     if (!leaderboardDiv) {

I changed the regular expression to filter cases like that