### PR TITLE
Fix OPENROUTER problem with the model names

### DIFF
--- a/pilot/utils/llm_connection.py
+++ b/pilot/utils/llm_connection.py
@@ -137,7 +137,7 @@ def create_gpt_chat_completion(messages: List[dict], req_type, project,
     if prompt_data is not None and function_call_message is not None:
         prompt_data['function_call_message'] = function_call_message
 
-    if '/' in model_name:
+    if '/' in model_name and os.getenv('ENDPOINT') != 'OPENROUTER':
         model_provider, model_name = model_name.split('/', 1)
     else:
         model_provider = 'openai'


### PR DESCRIPTION
If you try to use OpenRouter with any model - you got error:

```
{"error":{"message":"Model llama-3-70b-instruct:nitro is not available","code":404}, ...
```

because openrouter need's to have provider name together with the model name in one string.

This commit fix it for OpenRouter, so you can use:
`MODEL_NAME="meta-llama/llama-3-70b-instruct:nitro"`
in the config and it will work