### PR TITLE
Fix bugs: database config bugs

### DIFF
--- a/pilot/database/config.py
+++ b/pilot/database/config.py
@@ -1,5 +1,7 @@
 import os
+from dotenv import load_dotenv
 
+load_dotenv(override=True)
 DATABASE_TYPE = os.getenv("DATABASE_TYPE", "sqlite")
 DB_NAME = os.getenv("DB_NAME")
 DB_HOST = os.getenv("DB_HOST")

--- a/pilot/database/connection/postgres.py
+++ b/pilot/database/connection/postgres.py
@@ -1,11 +1,14 @@
 from peewee import PostgresqlDatabase
 from database.config import DB_NAME, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DATABASE_TYPE
+
 if DATABASE_TYPE == "postgres":
     import psycopg2
     from psycopg2.extensions import quote_ident
 
+
 def get_postgres_database():
     return PostgresqlDatabase(DB_NAME, user=DB_USER, password=DB_PASSWORD, host=DB_HOST, port=DB_PORT)
+
 
 def create_postgres_database():
     conn = psycopg2.connect(

--- a/pilot/database/connection/sqlite.py
+++ b/pilot/database/connection/sqlite.py
@@ -1,5 +1,6 @@
 from peewee import SqliteDatabase
 from database.config import DB_NAME
 
+
 def get_sqlite_database():
     return SqliteDatabase(DB_NAME)

--- a/pilot/database/database.py
+++ b/pilot/database/database.py
@@ -1,6 +1,7 @@
 from playhouse.shortcuts import model_to_dict
 from utils.style import color_yellow, color_red
 from peewee import DoesNotExist, IntegrityError
+import sqlite3
 from functools import reduce
 import operator
 from database.config import DB_NAME, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DATABASE_TYPE
@@ -8,7 +9,6 @@ if DATABASE_TYPE == "postgres":
     import psycopg2
     from psycopg2.extensions import quote_ident
 
-import os
 from const.common import PROMPT_DATA_TO_IGNORE, STEPS
 from logger.logger import logger
 from database.models.components.base_models import database
@@ -585,6 +585,9 @@ def create_database():
         cursor.execute(f"CREATE DATABASE {safe_db_name}")
 
         cursor.close()
+        conn.close()
+    elif DATABASE_TYPE == "sqlite":
+        conn = sqlite3.connect(DB_NAME)
         conn.close()
     else:
         pass

--- a/pilot/db_init.py
+++ b/pilot/db_init.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
-load_dotenv(override=True)
 from database.database import create_tables, drop_tables
+
+load_dotenv(override=True)
 
 drop_tables()
 create_tables()


### PR DESCRIPTION
This PR fixes two bugs about database.
### config.py read env values before loading .env file
pilot/database/config.py loads environment variable at project startup. This may set variables in config.py before executing the load_dotenv function in main.py. In this case, the database settings in .env file will not take effect.
### sqlite database not created
pilot/database/database.py will not create sqlite database in create_database function. If DATABASE_TYPE equals "sqlite", create_database will not create the database file.
### code reformat
Reformat postgres.py and db_init.py