### PR TITLE
Fix log

### DIFF
--- a/core/log/__init__.py
+++ b/core/log/__init__.py
@@ -12,7 +12,7 @@ def setup(config: LogConfig, force: bool = False):
     """
 
     root = getLogger()
-    logger = getLogger("pythagora")
+    logger = getLogger("core")
     # Only clear/remove existing log handlers if we're forcing a new setup
     if not force and (root.handlers or logger.handlers):
         return

--- a/tests/log/test_log.py
+++ b/tests/log/test_log.py
@@ -9,7 +9,7 @@ def test_file_handler(tmp_path):
     cfg = LogConfig(level="DEBUG", output=output)
     setup(cfg, force=True)
 
-    logger = get_logger("pythagora")
+    logger = get_logger("core")
     logger.debug("debug message")
 
     assert len(logger.handlers) == 1
@@ -25,7 +25,7 @@ def test_log_level(capsys):
     cfg = LogConfig(level="WARNING", output=None)
     setup(cfg, force=True)
 
-    logger = get_logger("pythagora.test_default_setup")
+    logger = get_logger("core.test_default_setup")
     logger.debug("debug message")
     logger.info("info message")
     logger.warning("warning message")


### PR DESCRIPTION
We've changed package name from `pythagora` to `core` at the last minute, this is a related bugfix. The logger kept using the old name, thus logging nothing.
