### PR TITLE
Prevent loops in task reviewer

### DIFF
--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -100,12 +100,6 @@ class Developer(BaseAgent):
         :param review_feedback: If provided, the task review feedback is broken down instead of the current iteration
         :return: AgentResponse.done(self) when the breakdown is done
         """
-        if self.current_state.unfinished_steps:
-            # if this happens, it's most probably a bug as we should have gone through all the
-            # steps before getting new new iteration instructions
-            log.warning(
-                f"Unfinished steps found before the next iteration is broken down: {self.current_state.unfinished_steps}"
-            )
 
         if review_feedback is not None:
             iteration = None

--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -241,7 +241,7 @@ class Developer(BaseAgent):
             }
             for step in response.steps
         ]
-        if len(self.next_state.unfinished_steps) > 0:
+        if len(self.next_state.unfinished_steps) > 0 and source != "review":
             self.next_state.steps += [
                 # TODO: add refactor step here once we have the refactor agent
                 {


### PR DESCRIPTION
I'm not sure this is correct, having a hard time with the verification.

I was able to get it to have a `review` source, and it doesn't get stuck, but I wasn't able to get a reproduction on the current state.

I also have some error entries that seem related, but I've had those before this change as well, which is interesting.

```
2024-05-23 14:35:53,981 WARNING [core.agents.developer] Unfinished steps found before the next iteration is broken down: [{'id': '53a7b3eb566a433bb1579eeb39565a38', 'completed': False, 'type': 'review_task', 'source': 'feature'}, {'id': 'f114d468eca54614b5bba715ebd6aaa9', 'completed': False, 'type': 'create_readme', 'source': 'feature'}]
```
README does get updated at the end of the task so I think that part is correct.