### PR TITLE
Show stacktrace

### DIFF
--- a/core/ui/base.py
+++ b/core/ui/base.py
@@ -234,4 +234,6 @@ class UIBase:
         raise NotImplementedError()
 
 
-__all__ = ["UISource", "AgentSource", "UserInput", "UIBase"]
+pythagora_source = UISource("Pythagora", "pythagora")
+
+__all__ = ["UISource", "AgentSource", "UserInput", "UIBase", "pythagora_source"]


### PR DESCRIPTION
If GPT Pilot crashes, shows formatted and filtered stacktrace that people can copy-paste in their bug reports:

![Screenshot from 2024-05-23 23-13-42](https://github.com/Pythagora-io/gpt-pilot/assets/3362/30cf217f-6ae4-4bd5-bd84-4570f4cb6eaa)
