### PR TITLE
use "continue" label for continue buttons; fix project template message

### DIFF
--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -55,9 +55,7 @@ class TaskSteps(BaseModel):
 
 
 class RelevantFiles(BaseModel):
-    relevant_files: list[str] = Field(
-        description="List of relevant files for the current task."
-    )
+    relevant_files: list[str] = Field(description="List of relevant files for the current task.")
 
 
 class Developer(BaseAgent):
@@ -206,20 +204,22 @@ class Developer(BaseAgent):
         return AgentResponse.done(self)
 
     async def get_relevant_files(
-            self,
-            user_feedback: Optional[str] = None,
-            solution_description: Optional[str] = None
+        self, user_feedback: Optional[str] = None, solution_description: Optional[str] = None
     ) -> AgentResponse:
         log.debug("Getting relevant files for the current task")
         await self.send_message("Figuring out which project files are relevant for the next task ...")
 
         llm = self.get_llm()
-        convo = AgentConvo(self).template(
-            "filter_files",
-            current_task=self.current_state.current_task,
-            user_feedback=user_feedback,
-            solution_description=solution_description,
-        ).require_schema(RelevantFiles)
+        convo = (
+            AgentConvo(self)
+            .template(
+                "filter_files",
+                current_task=self.current_state.current_task,
+                user_feedback=user_feedback,
+                solution_description=solution_description,
+            )
+            .require_schema(RelevantFiles)
+        )
 
         llm_response: list[str] = await llm(convo, parser=JSONParser(RelevantFiles), temperature=0)
 
@@ -290,9 +290,8 @@ class Developer(BaseAgent):
         user_response = await self.ask_question(
             "Edit the task description:",
             buttons={
-                # FIXME: Continue doesn't actually work, VSCode doesn't send the user
-                # message if it's clicked. Long term we need to fix the extension.
-                # "continue": "Continue",
+                # FIXME: must be lowercase becase VSCode doesn't recognize it otherwise. Needs a fix in the extension
+                "continue": "continue",
                 "cancel": "Cancel",
             },
             default="continue",

--- a/core/agents/spec_writer.py
+++ b/core/agents/spec_writer.py
@@ -26,13 +26,21 @@ class SpecWriter(BaseAgent):
         response = await self.ask_question(
             "Describe your app in as much detail as possible",
             allow_empty=False,
-            buttons={"example": "Start an example project"},
+            buttons={
+                # FIXME: must be lowercase becase VSCode doesn't recognize it otherwise. Needs a fix in the extension
+                "continue": "continue",
+                "example": "Start an example project",
+            },
         )
         if response.cancelled:
             return AgentResponse.error(self, "No project description")
 
         if response.button == "example":
             self.prepare_example_project()
+            return AgentResponse.done(self)
+        elif response.button == "continue":
+            # FIXME: Workaround for the fact that VSCode "continue" button does
+            # nothing but repeat the question. We reproduce this bug for bug here.
             return AgentResponse.done(self)
 
         spec = response.text

--- a/core/agents/troubleshooter.py
+++ b/core/agents/troubleshooter.py
@@ -175,9 +175,9 @@ class Troubleshooter(IterationPromptMixin, BaseAgent):
         if run_command:
             await self.ui.send_run_command(run_command)
 
-        buttons = {"continue": "Everything works, continue"}
+        buttons = {"continue": "continue"}
         if last_iteration:
-            buttons["loop"] = "I still have the same issue"
+            buttons["loop"] = "I'm stuck in a loop"
 
         user_response = await self.ask_question(
             test_message,

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -66,7 +66,7 @@ async def start_new_project(sm: StateManager, ui: UIBase) -> bool:
     :param ui: User interface.
     :return: True if the project was created successfully, False otherwise.
     """
-    user_input = await ui.ask_question("What is the name of the project", allow_empty=False, source=pythagora_source)
+    user_input = await ui.ask_question("What is the project name?", allow_empty=False, source=pythagora_source)
     if user_input.cancelled:
         return False
 

--- a/core/templates/registry.py
+++ b/core/templates/registry.py
@@ -92,3 +92,17 @@ def get_template_summary(template_name: str) -> Optional[str]:
         return None
     template = PROJECT_TEMPLATES[template_name]
     return template["summary"]
+
+
+def get_template_description(template_name: str) -> Optional[str]:
+    """
+    Get the description of a project template.
+
+    :param template_name: The name of the project template.
+    :return: A summary of the template, or None if no template was found.
+    """
+    if not template_name or template_name not in PROJECT_TEMPLATES:
+        log.warning(f"Project template '{template_name}' not found, ignoring")
+        return None
+    template = PROJECT_TEMPLATES[template_name]
+    return template["description"]


### PR DESCRIPTION
The button labels must be "continue" (uncapitalized) because VSCode extension currently has special handling for those.

Until the extension is fixed, we must use the same to interoperate.

This also has two small fixes:
* wording (project name, loop button)
* show template description when applied, instead of internal name
