### PR TITLE
Check LLM API before doing anything else.

### DIFF
--- a/core/agents/orchestrator.py
+++ b/core/agents/orchestrator.py
@@ -15,8 +15,6 @@ from core.agents.task_reviewer import TaskReviewer
 from core.agents.tech_lead import TechLead
 from core.agents.tech_writer import TechnicalWriter
 from core.agents.troubleshooter import Troubleshooter
-from core.config import LLMProvider, get_config
-from core.llm.convo import Convo
 from core.log import get_logger
 from core.telemetry import telemetry
 from core.ui.base import ProjectStage

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -93,6 +93,9 @@ async def llm_api_check(ui: UIBase) -> bool:
             log.warning(f"API check for {llm_config.provider.value} failed with: {err}")
             success = False
 
+    if not success:
+        telemetry.set("end_result", "failure:api-error")
+
     return success
 
 

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -8,7 +8,6 @@ from core.config import LLMProvider, get_config
 from core.db.session import SessionManager
 from core.db.v0importer import LegacyDatabaseImporter
 from core.llm.base import APIError, BaseLLMClient
-from core.llm.convo import Convo
 from core.log import get_logger
 from core.state.state_manager import StateManager
 from core.telemetry import telemetry

--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -4,7 +4,7 @@ from asyncio import run
 
 from core.agents.orchestrator import Orchestrator
 from core.cli.helpers import delete_project, init, list_projects, list_projects_json, load_project, show_config
-from core.config import get_config
+from core.config import LLMProvider, get_config
 from core.db.session import SessionManager
 from core.db.v0importer import LegacyDatabaseImporter
 from core.llm.base import APIError, BaseLLMClient
@@ -70,22 +70,24 @@ async def llm_api_check(ui: UIBase) -> bool:
 
     config = get_config()
 
-    buffer = []
-    async def stream_handler(msg: str):
-        if msg:
-            buffer.append(msg)
-    async def error_handler(err, message):
-        buffer.append(str(err))
+    async def handler(*args, **kwargs):
+        pass
 
     success = True
+    checked_llms: set[LLMProvider] = set()
     for llm_config in config.all_llms():
+        if llm_config.provider in checked_llms:
+            continue
+
         client_class = BaseLLMClient.for_provider(llm_config.provider)
-        llm_client = client_class(llm_config, stream_handler=stream_handler, error_handler=error_handler)
+        llm_client = client_class(llm_config, stream_handler=handler, error_handler=handler)
         try:
             resp = await llm_client.api_check()
             if not resp:
                 success = False
                 log.warning(f"API check for {llm_config.provider.value} failed.")
+            else:
+                log.info(f"API check for {llm_config.provider.value} succeeded.")
         except APIError as err:
             await ui.send_message(f"API check for {llm_config.provider.value} failed with: {err}")
             log.warning(f"API check for {llm_config.provider.value} failed with: {err}")
@@ -148,8 +150,6 @@ async def async_main(
     if not ui_started:
         return False
 
-    # We want to check LLM connectivity before doing anything else.
-    # make an object here, send in UI so we can notify the UI of failed checks
     if not await llm_api_check(ui):
         return False
 

--- a/core/config/__init__.py
+++ b/core/config/__init__.py
@@ -299,6 +299,13 @@ class Config(_StrictModel):
         provider_config = self.llm[agent_config.provider]
         return LLMConfig.from_provider_and_agent_configs(provider_config, agent_config)
 
+    def all_llms(self) -> list[LLMConfig]:
+        """
+        Get configuration for all defined LLMs.
+        """
+
+        return [self.llm_for_agent(agent) for agent in self.agent]
+
 
 class ConfigLoader:
     """

--- a/core/llm/base.py
+++ b/core/llm/base.py
@@ -268,6 +268,25 @@ class BaseLLMClient:
 
         return response, request_log
 
+    async def api_check(self) -> bool:
+        """
+        Perform an LLM API check.
+
+        :return: True if the check was successful, False otherwise.
+        """
+
+        convo = Convo()
+        convo.user(
+            " ".join(
+                [
+                    "This is a connection test. If you can see this,",
+                    "please respond only with 'START' and nothing else.",
+                ]
+            )
+        )
+        resp, _log = await self(convo)
+        return bool(resp)
+
     @staticmethod
     def for_provider(provider: LLMProvider) -> type["BaseLLMClient"]:
         """

--- a/core/llm/base.py
+++ b/core/llm/base.py
@@ -192,7 +192,8 @@ class BaseLLMClient:
                 wait_time = self.rate_limit_sleep(err)
                 if wait_time:
                     message = f"We've hit {self.config.provider.value} rate limit. Sleeping for {wait_time.seconds} seconds..."
-                    await self.error_handler(LLMError.RATE_LIMITED, message)
+                    if self.error_handler:
+                        await self.error_handler(LLMError.RATE_LIMITED, message)
                     await asyncio.sleep(wait_time.seconds)
                     continue
                 else:
@@ -207,9 +208,10 @@ class BaseLLMClient:
                 err_msg = err.response.json().get("error", {}).get("message", "Incorrect API key")
                 if "[BricksLLM]" in err_msg:
                     # We only want to show the key expired message if it's from Bricks
-                    should_retry = await self.error_handler(LLMError.KEY_EXPIRED)
-                    if should_retry:
-                        continue
+                    if self.error_handler:
+                        should_retry = await self.error_handler(LLMError.KEY_EXPIRED)
+                        if should_retry:
+                            continue
 
                 raise APIError(err_msg) from err
             except (openai.APIStatusError, anthropic.APIStatusError, groq.APIStatusError) as err:
@@ -276,14 +278,8 @@ class BaseLLMClient:
         """
 
         convo = Convo()
-        convo.user(
-            " ".join(
-                [
-                    "This is a connection test. If you can see this,",
-                    "please respond only with 'START' and nothing else.",
-                ]
-            )
-        )
+        msg = "This is a connection test. If you can see this, please respond only with 'START' and nothing else."
+        convo.user(msg)
         resp, _log = await self(convo)
         return bool(resp)
 

--- a/tests/agents/test_orchestrator.py
+++ b/tests/agents/test_orchestrator.py
@@ -1,55 +1,9 @@
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from core.agents.orchestrator import Orchestrator
 from core.state.state_manager import StateManager
-from core.ui.console import PlainConsoleUI
-
-
-@pytest.mark.asyncio
-@patch("core.agents.base.BaseLLMClient")
-@patch("core.state.state_manager.StateManager")
-async def test_check_llms_are_accessible(mock_StateManager, mock_BaseLLMClient):
-    mock_sm = mock_StateManager.return_value
-    mock_sm.log_llm_request = AsyncMock()
-
-    mock_OpenAIClient = mock_BaseLLMClient.for_provider.return_value
-    mock_client = AsyncMock(return_value=("START", "log"))
-    mock_OpenAIClient.return_value = mock_client
-
-    orca = Orchestrator(mock_sm, PlainConsoleUI())
-    assert await orca.test_llm_access()
-
-
-@pytest.mark.asyncio
-@patch("core.agents.base.BaseLLMClient")
-@patch("core.state.state_manager.StateManager")
-async def test_check_llms_returns_fail_if_one_fails(mock_StateManager, mock_BaseLLMClient):
-    mock_sm = mock_StateManager.return_value
-    mock_sm.log_llm_request = AsyncMock()
-
-    mock_OpenAIClient = mock_BaseLLMClient.for_provider.return_value
-    mock_client = AsyncMock(return_value=(None, "log"))
-    mock_OpenAIClient.return_value = mock_client
-
-    orca = Orchestrator(mock_sm, PlainConsoleUI())
-    assert await orca.test_llm_access() is False
-
-
-@pytest.mark.asyncio
-@patch("core.agents.base.BaseLLMClient")
-@patch("core.state.state_manager.StateManager")
-async def test_check_llms_returns_fail_if_llm_throws_exception(mock_StateManager, mock_BaseLLMClient):
-    mock_sm = mock_StateManager.return_value
-    mock_sm.log_llm_request = AsyncMock()
-
-    mock_OpenAIClient = mock_BaseLLMClient.for_provider.return_value
-    mock_client = AsyncMock(side_effect=ValueError("Invalid API key"))
-    mock_OpenAIClient.return_value = mock_client
-
-    orca = Orchestrator(mock_sm, PlainConsoleUI())
-    assert await orca.test_llm_access() is False
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -287,8 +287,10 @@ def test_init(tmp_path):
         ([], True, True),
     ],
 )
+@patch("core.cli.main.llm_api_check")
 @patch("core.cli.main.Orchestrator")
-async def test_main(mock_Orchestrator, args, run_orchestrator, retval, tmp_path):
+async def test_main(mock_Orchestrator, mock_llm_check, args, run_orchestrator, retval, tmp_path):
+    mock_llm_check.return_value = True
     config_file = write_test_config(tmp_path)
 
     class MockArgumentParser(ArgumentParser):
@@ -313,8 +315,10 @@ async def test_main(mock_Orchestrator, args, run_orchestrator, retval, tmp_path)
 
 
 @pytest.mark.asyncio
+@patch("core.cli.main.llm_api_check")
 @patch("core.cli.main.Orchestrator")
-async def test_main_handles_crash(mock_Orchestrator, tmp_path, capsys):
+async def test_main_handles_crash(mock_Orchestrator, mock_llm_check, tmp_path):
+    mock_llm_check.return_value = True
     config_file = write_test_config(tmp_path)
 
     class MockArgumentParser(ArgumentParser):


### PR DESCRIPTION
Moved this out of `Orchestrator` so it can be done before we even have an agent. Also, didn't like the previuos logic in the `Orchestrator`, it was only there becuase we had an access to an LLM there.

Fail if a single check fails.

Tested by fiddling with config, here's what it looks like if it fails:
![image](https://github.com/Pythagora-io/gpt-pilot/assets/192281/586d394d-0893-45ab-840a-11cc3e24a345)

```
❯ python main.py --local-ipc-port 8125 --project aa74d7405b3144ae9077ac2af04a816e
2024-05-24 11:11:24,731 WARNING [core.cli.main] API check for openai failed with: The model `gpt-4-turbo123` does not exist or you do not have access to it.
```

Only tests once per LLM provider.

@senko if you could take a peek at that telemetry entry, I see `set` entries in the `async_main` but I don't see a start there, am I doing something wrong?