### PR TITLE
Remove files crash

### DIFF
--- a/core/agents/orchestrator.py
+++ b/core/agents/orchestrator.py
@@ -275,14 +275,14 @@ class Orchestrator(BaseAgent):
             raise ValueError(f"Unknown step type: {step_type}")
 
     async def import_files(self) -> Optional[AgentResponse]:
-        imported_files, removed_files = await self.state_manager.import_files()
-        if not imported_files and not removed_files:
+        imported_files, removed_paths = await self.state_manager.import_files()
+        if not imported_files and not removed_paths:
             return None
 
         if imported_files:
             log.info(f"Imported new/changed files to project: {', '.join(f.path for f in imported_files)}")
-        if removed_files:
-            log.info(f"Removed files from project: {', '.join(f.path for f in removed_files)}")
+        if removed_paths:
+            log.info(f"Removed files from project: {', '.join(removed_paths)}")
 
         input_required_files: list[dict[str, int]] = []
         for file in imported_files:
@@ -295,7 +295,7 @@ class Orchestrator(BaseAgent):
             return AgentResponse.input_required(self, input_required_files)
 
         # Commit the newly imported file
-        log.debug(f"Committing imported files as a separate step {self.current_state.step_index}")
+        log.debug(f"Committing imported/removed files as a separate step {self.current_state.step_index}")
         await self.state_manager.commit()
         return None
 

--- a/core/db/models/base.py
+++ b/core/db/models/base.py
@@ -31,15 +31,6 @@ class Base(AsyncAttrs, DeclarativeBase):
         }
     )
 
-    def __eq__(self, other) -> bool:
-        """
-        Two instances of the same model class are the same if their
-        IDs are the same.
-
-        This allows comparison of models bound to different sessions.
-        """
-        return isinstance(other, self.__class__) and self.id == other.id
-
     def __repr__(self) -> str:
         """Return a string representation of the model."""
         return f"<{self.__class__.__name__}(id={self.id})>"

--- a/core/state/state_manager.py
+++ b/core/state/state_manager.py
@@ -431,7 +431,7 @@ class StateManager:
                 log.debug(f"File {path} was removed from workspace, deleting from project")
                 next_state_file = self.next_state.get_file_by_path(path)
                 self.next_state.files.remove(next_state_file)
-                removed_files.append(file)
+                removed_files.append(file.path)
 
         return imported_files, removed_files
 

--- a/tests/db/test_project_state.py
+++ b/tests/db/test_project_state.py
@@ -41,8 +41,8 @@ async def test_get_by_id_preloads_branch_project_files(testdb):
 
     # If "get_by_id" doesn't populate branch and project and load the files,
     # this will crash because they can't be lazy-loaded without an await.
-    assert s.branch == state.branch
-    assert s.branch.project == state.branch.project
+    assert s.branch.id == state.branch.id
+    assert s.branch.project.id == state.branch.project.id
     assert s.files[0].content.content == "hello world"
 
 

--- a/tests/state/test_state_manager.py
+++ b/tests/state/test_state_manager.py
@@ -43,7 +43,7 @@ async def test_load_project(mock_get_config, testmanager):
 
     project_state = await sm.load_project(project_id=project.id)
 
-    assert project_state.branch.project == project
+    assert project_state.branch.project.id == project.id
 
 
 @pytest.mark.asyncio
@@ -70,7 +70,7 @@ async def test_load_project_branch(mock_get_config, testmanager):
 
     project_state = await sm.load_project(branch_id=project.branches[0].id)
 
-    assert project_state.branch.project == project
+    assert project_state.branch.project.id == project.id
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,7 @@ async def test_load_specific_step(mock_get_config, testmanager):
 
     project_state = await sm.load_project(project_id=project.id, step_index=project.branches[0].states[0].step_index)
 
-    assert project_state.branch.project == project
+    assert project_state.branch.project.id == project.id
 
 
 @pytest.mark.asyncio
@@ -187,7 +187,7 @@ async def test_importing_changed_files_to_db(mock_get_config, tmpdir, testmanage
         assert os.path.exists(os.path.join(tmpdir, "test", "file2.txt"))
         assert os.path.exists(os.path.join(tmpdir, "test", "file3.txt"))
 
-        db_files = set([f.path for f in sm.current_state.files])
+        db_files = set(f.path for f in sm.current_state.files)
         assert "file1.txt" not in db_files
         assert "file2.txt" in db_files
         assert "file3.txt" in db_files


### PR DESCRIPTION
This fixes an error in which a file gets removed but still remains in state `files` list and crashing when Pythagora tries to handle it:

The second commit is some small related cleanup, so best to review commit by commit.

```
2024-05-24 15:21:26,606 DEBUG [core.state.state_manager] File routes/stripeWebhookRoutes.js was removed from workspace, deleting from project
2024-05-24 15:21:26,606 INFO [core.agents.orchestrator] Removed files from project: routes/stripeWebhookRoutes.js
2024-05-24 15:21:26,606 DEBUG [core.agents.orchestrator] Committing imported files as a separate step 282
2024-05-24 15:21:26,608 DEBUG [core.db.session] Connected to database sqlite+aiosqlite:///pythagora.db
sys:1: SAWarning: Object of type <File> not in session, add operation along 'ProjectState.files' will not proceed
2024-05-24 15:21:26,640 ERROR [core.cli.main] Uncaught exception: 'NoneType' object has no attribute 'content'
Traceback (most recent call last):
  File "/home/senko/Projects/Pythagora/gpt-pilot/core/cli/main.py", line 37, in run_project
    success = await orca.run()
              ^^^^^^^^^^^^^^^^
  File "/home/senko/Projects/Pythagora/gpt-pilot/core/agents/orchestrator.py", line 64, in run
    await self.update_stats()
  File "/home/senko/Projects/Pythagora/gpt-pilot/core/agents/orchestrator.py", line 326, in update_stats
    total_lines += len(file.content.content.splitlines())
                       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'content'
```
