### PR TITLE
cache user test instructions between iterations

### DIFF
--- a/core/agents/tech_lead.py
+++ b/core/agents/tech_lead.py
@@ -63,6 +63,7 @@ class TechLead(BaseAgent):
                 "name": "Initial Project",
                 "source": "app",
                 "description": self.current_state.specification.description,
+                "test_instructions": None,
                 "summary": None,
                 "completed": False,
                 "complexity": self.current_state.specification.complexity,
@@ -104,6 +105,7 @@ class TechLead(BaseAgent):
             {
                 "id": uuid4().hex,
                 "name": f"Feature #{len(self.current_state.epics)}",
+                "test_instructions": None,
                 "source": "feature",
                 "description": response.text,
                 "summary": None,

--- a/core/db/models/project_state.py
+++ b/core/db/models/project_state.py
@@ -203,6 +203,7 @@ class ProjectState(Base):
             files=[],
             relevant_files=deepcopy(self.relevant_files),
             modified_files=deepcopy(self.modified_files),
+            run_command=self.run_command,
         )
 
         session: AsyncSession = inspect(self).async_session
@@ -263,13 +264,23 @@ class ProjectState(Base):
 
     def flag_iterations_as_modified(self):
         """
-        Flag the iteration field as having been modified
+        Flag the iterations field as having been modified
 
         Used by Agents that perform modifications within the mutable iterations field,
         to tell the database that it was modified and should get saved (as SQLalchemy
         can't detect changes in mutable fields by itself).
         """
         flag_modified(self, "iterations")
+
+    def flag_tasks_as_modified(self):
+        """
+        Flag the tasks field as having been modified
+
+        Used by Agents that perform modifications within the mutable tasks field,
+        to tell the database that it was modified and should get saved (as SQLalchemy
+        can't detect changes in mutable fields by itself).
+        """
+        flag_modified(self, "tasks")
 
     def get_file_by_path(self, path: str) -> Optional["File"]:
         """


### PR DESCRIPTION
Cache user testing instructions between iterations

First iteration (ask LLM to generate run command and test instructions):

![Screenshot from 2024-05-25 12-05-57](https://github.com/Pythagora-io/gpt-pilot/assets/3362/cf90c1dc-1b7f-4635-a06d-aff77b424472)

Second iteration (use cached):

![Screenshot from 2024-05-25 12-06-08](https://github.com/Pythagora-io/gpt-pilot/assets/3362/b102af84-684e-48b8-81c9-a600c81124a0)



Database:

![Screenshot from 2024-05-25 12-07-28](https://github.com/Pythagora-io/gpt-pilot/assets/3362/0ed824df-bdea-4326-9e1e-8f43b0292ed7)
