### PR TITLE
show a more useful error message if python environment is not (comple…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,29 @@
 #!/usr/bin/env python
 
-from sys import exit
 
-from core.cli.main import run_pythagora
+import os.path
+import sys
 
-exit(run_pythagora())
+try:
+    from core.cli.main import run_pythagora
+except ImportError:
+    pythagora_root = os.path.dirname(os.path.dirname(__file__))
+    venv_path = os.path.join(pythagora_root, "venv")
+    requirements_path = os.path.join(pythagora_root, "requirements.txt")
+    if sys.prefix == sys.base_prefix:
+        venv_python_path = os.path.join(venv_path, "scripts" if sys.platform == "win32" else "bin", "python")
+        print("Python environment for Pythagora is not set up.", file=sys.stderr)
+        print(f"Please create Python virtual environment: {sys.executable} -m venv {venv_path}", file=sys.stderr)
+        print(
+            f"Then install the required dependencies with: {venv_python_path} -m pip install -r {requirements_path}",
+            file=sys.stderr,
+        )
+    else:
+        print("Python environment for Pythagora is not completely set up.", file=sys.stderr)
+        print(
+            f"Please run `{sys.executable} -m pip install -r {requirements_path}` to finish Python setup, and rerun Pythagora.",
+            file=sys.stderr,
+        )
+    sys.exit(255)
+
+sys.exit(run_pythagora())


### PR DESCRIPTION
If python environment is not correctly set up for any reason, we'll fail at import. Detect this and show a less scary and more informative error message:

![Screenshot from 2024-05-25 12-46-17](https://github.com/Pythagora-io/gpt-pilot/assets/3362/059d3f7a-c5f9-4497-bd90-b8f2fe28f53c)

(code for this lifted with minimal adaptation from 0.1)

