### PR TITLE
Prevent lazy loading of SQLAlchemy relationships.

### DIFF
--- a/core/db/models/branch.py
+++ b/core/db/models/branch.py
@@ -29,10 +29,10 @@ class Branch(Base):
 
     # Relationships
     project: Mapped["Project"] = relationship(back_populates="branches", lazy="selectin")
-    states: Mapped[list["ProjectState"]] = relationship(back_populates="branch", cascade="all")
-    llm_requests: Mapped[list["LLMRequest"]] = relationship(back_populates="branch", cascade="all")
-    user_inputs: Mapped[list["UserInput"]] = relationship(back_populates="branch", cascade="all")
-    exec_logs: Mapped[list["ExecLog"]] = relationship(back_populates="branch", cascade="all")
+    states: Mapped[list["ProjectState"]] = relationship(back_populates="branch", cascade="all", lazy="raise")
+    llm_requests: Mapped[list["LLMRequest"]] = relationship(back_populates="branch", cascade="all", lazy="raise")
+    user_inputs: Mapped[list["UserInput"]] = relationship(back_populates="branch", cascade="all", lazy="raise")
+    exec_logs: Mapped[list["ExecLog"]] = relationship(back_populates="branch", cascade="all", lazy="raise")
 
     @staticmethod
     async def get_by_id(session: "AsyncSession", branch_id: Union[str, UUID]) -> Optional["Branch"]:

--- a/core/db/models/exec_log.py
+++ b/core/db/models/exec_log.py
@@ -34,8 +34,8 @@ class ExecLog(Base):
     success: Mapped[bool] = mapped_column()
 
     # Relationships
-    branch: Mapped["Branch"] = relationship(back_populates="exec_logs")
-    project_state: Mapped["ProjectState"] = relationship(back_populates="exec_logs")
+    branch: Mapped["Branch"] = relationship(back_populates="exec_logs", lazy="raise")
+    project_state: Mapped["ProjectState"] = relationship(back_populates="exec_logs", lazy="raise")
 
     @classmethod
     def from_exec_log(cls, project_state: "ProjectState", exec_log: ExecLogData) -> "ExecLog":

--- a/core/db/models/file.py
+++ b/core/db/models/file.py
@@ -24,7 +24,7 @@ class File(Base):
     meta: Mapped[dict] = mapped_column(default=dict, server_default="{}")
 
     # Relationships
-    project_state: Mapped[Optional["ProjectState"]] = relationship(back_populates="files")
+    project_state: Mapped[Optional["ProjectState"]] = relationship(back_populates="files", lazy="raise")
     content: Mapped["FileContent"] = relationship(back_populates="files", lazy="selectin")
 
     def clone(self) -> "File":

--- a/core/db/models/file_content.py
+++ b/core/db/models/file_content.py
@@ -20,7 +20,7 @@ class FileContent(Base):
     content: Mapped[str] = mapped_column()
 
     # Relationships
-    files: Mapped[list["File"]] = relationship(back_populates="content")
+    files: Mapped[list["File"]] = relationship(back_populates="content", lazy="raise")
 
     @classmethod
     async def store(cls, session: AsyncSession, hash: str, content: str) -> "FileContent":

--- a/core/db/models/llm_request.py
+++ b/core/db/models/llm_request.py
@@ -38,8 +38,8 @@ class LLMRequest(Base):
     error: Mapped[Optional[str]] = mapped_column()
 
     # Relationships
-    branch: Mapped["Branch"] = relationship(back_populates="llm_requests")
-    project_state: Mapped["ProjectState"] = relationship(back_populates="llm_requests")
+    branch: Mapped["Branch"] = relationship(back_populates="llm_requests", lazy="raise")
+    project_state: Mapped["ProjectState"] = relationship(back_populates="llm_requests", lazy="raise")
 
     @classmethod
     def from_request_log(

--- a/core/db/models/project.py
+++ b/core/db/models/project.py
@@ -29,7 +29,7 @@ class Project(Base):
     )
 
     # Relationships
-    branches: Mapped[list["Branch"]] = relationship(back_populates="project", cascade="all")
+    branches: Mapped[list["Branch"]] = relationship(back_populates="project", cascade="all", lazy="raise")
 
     @staticmethod
     async def get_by_id(session: "AsyncSession", project_id: Union[str, UUID]) -> Optional["Project"]:

--- a/core/db/models/project_state.py
+++ b/core/db/models/project_state.py
@@ -49,17 +49,19 @@ class ProjectState(Base):
         back_populates="next_state",
         remote_side=[id],
         single_parent=True,
+        lazy="raise",
+        cascade="delete",
     )
-    next_state: Mapped[Optional["ProjectState"]] = relationship(back_populates="prev_state")
+    next_state: Mapped[Optional["ProjectState"]] = relationship(back_populates="prev_state", lazy="raise")
     files: Mapped[list["File"]] = relationship(
         back_populates="project_state",
         lazy="selectin",
         cascade="all,delete-orphan",
     )
     specification: Mapped["Specification"] = relationship(back_populates="project_states", lazy="selectin")
-    llm_requests: Mapped[list["LLMRequest"]] = relationship(back_populates="project_state", cascade="all")
-    user_inputs: Mapped[list["UserInput"]] = relationship(back_populates="project_state", cascade="all")
-    exec_logs: Mapped[list["ExecLog"]] = relationship(back_populates="project_state", cascade="all")
+    llm_requests: Mapped[list["LLMRequest"]] = relationship(back_populates="project_state", cascade="all", lazy="raise")
+    user_inputs: Mapped[list["UserInput"]] = relationship(back_populates="project_state", cascade="all", lazy="raise")
+    exec_logs: Mapped[list["ExecLog"]] = relationship(back_populates="project_state", cascade="all", lazy="raise")
 
     @property
     def unfinished_steps(self) -> list[dict]:

--- a/core/db/models/specification.py
+++ b/core/db/models/specification.py
@@ -31,7 +31,7 @@ class Specification(Base):
     complexity: Mapped[str] = mapped_column(server_default=Complexity.HARD)
 
     # Relationships
-    project_states: Mapped[list["ProjectState"]] = relationship(back_populates="specification")
+    project_states: Mapped[list["ProjectState"]] = relationship(back_populates="specification", lazy="raise")
 
     def clone(self) -> "Specification":
         """

--- a/core/db/models/user_input.py
+++ b/core/db/models/user_input.py
@@ -29,8 +29,8 @@ class UserInput(Base):
     cancelled: Mapped[bool] = mapped_column()
 
     # Relationships
-    branch: Mapped["Branch"] = relationship(back_populates="user_inputs")
-    project_state: Mapped["ProjectState"] = relationship(back_populates="user_inputs")
+    branch: Mapped["Branch"] = relationship(back_populates="user_inputs", lazy="raise")
+    project_state: Mapped["ProjectState"] = relationship(back_populates="user_inputs", lazy="raise")
 
     @classmethod
     def from_user_input(cls, project_state: "ProjectState", question: str, user_input: UserInputData) -> "UserInput":

--- a/core/state/state_manager.py
+++ b/core/state/state_manager.py
@@ -416,8 +416,11 @@ class StateManager:
             files_in_workspace.add(path)
             content = self.file_system.read(path)
             saved_file = known_files.get(path)
-            if saved_file and saved_file.content.content == content:
-                continue
+
+            if saved_file:
+                await saved_file.awaitable_attrs.content
+                if saved_file.content.content == content:
+                    continue
 
             # TODO: unify this with self.save_file() / refactor that whole bit
             hash = self.file_system.hash_string(content)

--- a/tests/db/test_db.py
+++ b/tests/db/test_db.py
@@ -55,5 +55,12 @@ async def test_deleting_project_state_clears_back_references(testdb):
     await testdb.commit()
 
     # Check the second one still exists and has no back reference
-    await testdb.refresh(state2)
+    await testdb.refresh(state2, attribute_names=["prev_state"])
+
+    # After adding lazy="raise" to the the prev_state relationship,
+    # this assertion would fail with an ORM exception, *unless* we add
+    # the prev_state in the attribute_names in the above `refresh()`,
+    # which then causes SQLAlchemy to explicitly load that relationship
+    # Alternative is to just assert `prev_state_id is None`, which works
+    # without the attribute_names
     assert state2.prev_state is None


### PR DESCRIPTION
I had an issue with one relationship, which is `FileContent.files`. When I added `lazy="raise"` there, `import_files()` in `StateManager` started failing, and I had to add an `await` there. I'm not sure why that fixes it.

I'm not sure I understand what "selectin" does, accorting to the docs (https://docs.sqlalchemy.org/en/20/orm/relationship_api.html), "selectin" is an eagerly loading strategy, so not sure why we have to do `await obh.awaitable_attrs.field`.
