### PR TITLE
Cleanly exit Pythagora core if UI is closed

### DIFF
--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -11,7 +11,7 @@ from core.llm.base import APIError, BaseLLMClient
 from core.log import get_logger
 from core.state.state_manager import StateManager
 from core.telemetry import telemetry
-from core.ui.base import UIBase, pythagora_source
+from core.ui.base import UIBase, UIClosedError, pythagora_source
 
 log = get_logger(__name__)
 
@@ -37,7 +37,7 @@ async def run_project(sm: StateManager, ui: UIBase) -> bool:
     try:
         success = await orca.run()
         telemetry.set("end_result", "success:exit" if success else "failure:api-error")
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, UIClosedError):
         log.info("Interrupted by user")
         telemetry.set("end_result", "interrupt")
         await sm.rollback()

--- a/core/ui/base.py
+++ b/core/ui/base.py
@@ -10,6 +10,10 @@ class ProjectStage(str, Enum):
     CODING = "coding"
 
 
+class UIClosedError(Exception):
+    """The user interface has been closed (user stoped Pythagora)."""
+
+
 class UISource:
     """
     Source for UI messages.

--- a/core/ui/console.py
+++ b/core/ui/console.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from core.log import get_logger
-from core.ui.base import ProjectStage, UIBase, UISource, UserInput
+from core.ui.base import ProjectStage, UIBase, UIClosedError, UISource, UserInput
 
 log = get_logger(__name__)
 
@@ -61,7 +61,7 @@ class PlainConsoleUI(UIBase):
             try:
                 choice = input("> ").strip()
             except KeyboardInterrupt:
-                return UserInput(cancelled=True)
+                raise UIClosedError()
             if not choice and default:
                 choice = default
             if buttons and choice in buttons:

--- a/tests/ui/test_console.py
+++ b/tests/ui/test_console.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from core.ui.base import AgentSource
+from core.ui.base import AgentSource, UIClosedError
 from core.ui.console import PlainConsoleUI
 
 
@@ -77,11 +77,8 @@ async def test_ask_question_interrupted(mock_input):
     ui = PlainConsoleUI()
 
     await ui.start()
-    input = await ui.ask_question("Hello, how are you?")
-
-    assert input.cancelled is True
-    assert input.button is None
-    assert input.text is None
+    with pytest.raises(UIClosedError):
+        await ui.ask_question("Hello, how are you?")
 
     await ui.stop()
 

--- a/tests/ui/test_ipc_client.py
+++ b/tests/ui/test_ipc_client.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from core.config import LocalIPCConfig
-from core.ui.base import AgentSource
+from core.ui.base import AgentSource, UIClosedError
 from core.ui.ipc_client import IPCClientUI
 
 if sys.platform == "win32":
@@ -160,11 +160,8 @@ async def test_server_closes_connection():
         connected = await ui.start()
         assert connected is True
 
-        answer = await ui.ask_question("Hello, how are you?")
-
-        await ui.stop()
-
-    assert answer.cancelled is True
+        with pytest.raises(UIClosedError):
+            await ui.ask_question("Hello, how are you?")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Before:

```
  File "/home/senko/Projects/Pythagora/gpt-pilot/core/ui/ipc_client.py", line 119, in _send
    await self.writer.drain()
  File "/usr/lib/python3.11/asyncio/streams.py", line 366, in drain
    raise exc
  File "/usr/lib/python3.11/asyncio/selector_events.py", line 1057, in write
    n = self._sock.send(data)
        ^^^^^^^^^^^^^^^^^^^^^
BrokenPipeError: [Errno 32] Broken pipe
2024-05-27 16:14:05,696 DEBUG [core.ui.ipc_client] Sending message: [Stopping Pythagora due to error:

File `core/cli/main.py`, line 38, in run_project
    success = await orca.run()
File `core/agents/orchestrator.py`, line 62, in run
    response = await agent.run()
File `core/agents/tech_lead.py`, line 57, in run
    return await self.ask_for_new_feature()
File `core/agents/tech_lead.py`, line 96, in ask_for_new_feature
    response = await self.ask_question(
File `core/agents/base.py`, line 91, in ask_question
    response = await self.ui.ask_question(
File `core/ui/ipc_client.py`, line 224, in ask_question
    response = await self._receive()
File `core/ui/ipc_client.py`, line 127, in _receive
    response = await self.reader.read(MESSAGE_SIZE_LIMIT)
File `core/ui/ipc_client.py`, line 119, in _send
    await self.writer.drain()
File `core/ui/ipc_client.py`, line 119, in _send
    await self.writer.drain()
File `core/ui/ipc_client.py`, line 119, in _send
    await self.writer.drain()
File `core/ui/ipc_client.py`, line 119, in _send
    await self.writer.drain()
File `core/ui/ipc_client.py`, line 119, in _send
    await self.writer.drain()
BrokenPipeError: [Errno 32] Broken pipe] from pythagora
2024-05-27 16:14:05,696 ERROR [core.ui.ipc_client] Connection lost while sending the message: [Errno 32] Broken pipe
```

Now:

```
2024-05-27 16:15:14,609 INFO [core.cli.main] Interrupted by user
```



