### PR TITLE
add default .env to template

### DIFF
--- a/core/templates/tpl/node_express_mongoose/.env
+++ b/core/templates/tpl/node_express_mongoose/.env
@@ -1,0 +1,8 @@
+# Port to listen on (example: 3000)
+PORT=3000
+
+# MongoDB database URL (example: mongodb://localhost/dbname)
+DATABASE_URL=mongodb://localhost/myDb # INPUT_REQUIRED {insert your MongoDB url here}
+
+# Session secret string (must be unique to your server)
+SESSION_SECRET={{ random_secret }}


### PR DESCRIPTION
Although `.env` files are usually not committed to the repository, we do want to commit this one because it belongs to a template.
