### PR TITLE
Retry when we get a generic LLM API error.

### DIFF
--- a/core/agents/base.py
+++ b/core/agents/base.py
@@ -135,7 +135,15 @@ class BaseAgent:
             )
             if answer.button == "yes":
                 return True
-
+        elif error == LLMError.GENERIC_API_ERROR:
+            await self.stream_handler(message)
+            answer = await self.ask_question(
+                "Would you like to retry the last step?",
+                buttons={"yes": "Yes", "no": "No"},
+                buttons_only=True,
+            )
+            if answer.button == "yes":
+                return True
         elif error == LLMError.RATE_LIMITED:
             await self.stream_handler(message)
 

--- a/core/agents/base.py
+++ b/core/agents/base.py
@@ -7,7 +7,7 @@ from core.llm.base import BaseLLMClient, LLMError
 from core.log import get_logger
 from core.proc.process_manager import ProcessManager
 from core.state.state_manager import StateManager
-from core.ui.base import AgentSource, UIBase, UserInput
+from core.ui.base import AgentSource, UIBase, UserInput, pythagora_source
 
 log = get_logger(__name__)
 
@@ -137,10 +137,11 @@ class BaseAgent:
                 return True
         elif error == LLMError.GENERIC_API_ERROR:
             await self.stream_handler(message)
-            answer = await self.ask_question(
-                "Would you like to retry the last step?",
+            answer = await self.ui.ask_question(
+                "Would you like to retry the failed request?",
                 buttons={"yes": "Yes", "no": "No"},
                 buttons_only=True,
+                source=pythagora_source,
             )
             if answer.button == "yes":
                 return True

--- a/core/llm/base.py
+++ b/core/llm/base.py
@@ -159,7 +159,26 @@ class BaseLLMClient:
         )
         t0 = time()
 
-        for _ in range(max_retries):
+        remaining_retries = max_retries
+        while True:
+            if remaining_retries == 0:
+                # We've run out of auto-retries
+                if request_log.error:
+                    last_error_msg = f"Error connecting to the LLM: {request_log.error}"
+                else:
+                    last_error_msg = "Error parsing LLM response"
+
+                # If we can, ask the user if they want to keep retrying
+                if self.error_handler:
+                    should_retry = await self.error_handler(LLMError.GENERIC_API_ERROR, message=last_error_msg)
+                    if should_retry:
+                        remaining_retries = max_retries
+                        continue
+
+                # They don't want to retry (or we can't ask them), raise the last error and stop Pythagora
+                raise APIError(last_error_msg)
+
+            remaining_retries -= 1
             request_log.messages = convo.messages[:]
             request_log.response = None
             request_log.error = None
@@ -240,18 +259,15 @@ class BaseLLMClient:
                 log.warning(f"API error: {err}", exc_info=True)
                 request_log.error = str(f"API error: {err}")
                 request_log.status = LLMRequestStatus.ERROR
-                return None, request_log
+                continue
             except (openai.APIError, anthropic.APIError, groq.APIError) as err:
                 # Generic LLM API error
                 # Make sure this handler is last in the chain as some of the above
                 # errors inherit from these `APIError` classes
                 log.warning(f"LLM API error {err}", exc_info=True)
-                msg = "LLM had an error processing our request."
-                if self.error_handler:
-                    should_retry = await self.error_handler(LLMError.GENERIC_API_ERROR, message=msg)
-                    if should_retry:
-                        continue
-                raise APIError(msg) from err
+                request_log.error = f"LLM had an error processing our request: {err}"
+                request_log.status = LLMRequestStatus.ERROR
+                continue
 
             request_log.response = response
 
@@ -268,10 +284,6 @@ class BaseLLMClient:
                     continue
             else:
                 break
-        else:
-            log.warning(f"Failed to parse response after {max_retries} retries")
-            response = None
-            request_log.status = LLMRequestStatus.ERROR
 
         t1 = time()
         request_log.duration = t1 - t0


### PR DESCRIPTION
Ask the user to retry when we get `{LLM Provider}.APIerror` exception.