### PR TITLE
parse single backtick blocks

### DIFF
--- a/core/llm/parser.py
+++ b/core/llm/parser.py
@@ -77,6 +77,9 @@ class OptionalCodeBlockParser:
             # Remove the first and last line. Note the first line may include syntax
             # highlighting, so we can't just remove the first 3 characters.
             text = "\n".join(text.splitlines()[1:-1]).strip()
+        elif "\n" not in text and text.startswith("`") and text.endswith("`"):
+            # Single-line code blocks are wrapped in single backticks
+            text = text[1:-1]
         return text
 
 

--- a/tests/llm/test_parser.py
+++ b/tests/llm/test_parser.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import pytest
 from pydantic import BaseModel, field_validator
 
-from core.llm.parser import CodeBlockParser, EnumParser, JSONParser, MultiCodeBlockParser
+from core.llm.parser import CodeBlockParser, EnumParser, JSONParser, MultiCodeBlockParser, OptionalCodeBlockParser
 
 
 @pytest.mark.parametrize(
@@ -188,3 +188,17 @@ def test_enum_parser(input, expected):
             parser(input)
     else:
         assert parser(input).value == expected
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("abc", "abc"),
+        ("watch this: `foo`", "watch this: `foo`"),
+        ("`hello world`", "hello world"),
+        ("```\nhello world\n```", "hello world"),
+    ],
+)
+def test_optional_block_parser(input, expected):
+    parser = OptionalCodeBlockParser()
+    assert parser(input) == expected


### PR DESCRIPTION
Sometimes the LLM wraps things in single backticks even though we ask nicely not to.