### PR TITLE
fix issue when one of match groups is NoneType

### DIFF
--- a/core/llm/openai_client.py
+++ b/core/llm/openai_client.py
@@ -104,13 +104,16 @@ class OpenAIClient(BaseLLMClient):
             match = re.search(time_regex, headers["x-ratelimit-reset-requests"])
 
         if match:
-            seconds = int(match.group(1)) * 3600 + int(match.group(2)) * 60 + int(match.group(3))
+            hours = int(match.group(1)) if match.group(1) else 0
+            minutes = int(match.group(2)) if match.group(2) else 0
+            seconds = int(match.group(3)) if match.group(3) else 0
+            total_seconds = hours * 3600 + minutes * 60 + seconds
         else:
             # Not sure how this would happen, we would have to get a RateLimitError,
             # but nothing (or invalid entry) in the `reset` field. Using a sane default.
-            seconds = 5
+            total_seconds = 5
 
-        return datetime.timedelta(seconds=seconds)
+        return datetime.timedelta(seconds=total_seconds)
 
 
 __all__ = ["OpenAIClient"]


### PR DESCRIPTION
Fix for issue:

```
File core/cli/main.py, line 38, in runproject
    success = await orca.run()
File core/agents/orchestrator.py, line 64, in run
    response = await agent.run()
File core/agents/developer.py, line 79, in run
    await self.getrelevant_files()
File core/agents/developer.py, line 223, in get_relevant_files
    llm_response: list[str] = await llm(convo, parser=JSONParser(RelevantFiles), temperature=0)
File core/agents/base.py, line 173, in client
    response, request_log = await llm_client(convo, **kwargs)
File core/llm/base.py, line 192, in __call
    wait_time = self.rate_limit_sleep(err)
File core/llm/openai_client.py, line 107, in rate_limit_sleep
    seconds = int(match.group(1)) * 3600 + int(match.group(2)) * 60 + int(match.group(3))
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```