### PR TITLE
Check task state before checking steps (so it can be skipped if needed)

### DIFF
--- a/core/agents/orchestrator.py
+++ b/core/agents/orchestrator.py
@@ -181,10 +181,9 @@ class Orchestrator(BaseAgent):
         ):
             # Ask the Tech Lead to break down the initial project or feature into tasks and apply project template
             return TechLead(self.state_manager, self.ui, process_manager=self.process_manager)
-        elif not state.steps and not state.iterations:
-            # Ask the Developer to break down current task into actionable steps
-            return Developer(self.state_manager, self.ui)
 
+        # Current task status must be checked before Developer is called because we might want
+        # to skip it instead of breaking it down
         current_task_status = state.current_task.get("status") if state.current_task else None
         if current_task_status:
             # Status of the current task is set first time after the task was reviewed by user
@@ -198,6 +197,10 @@ class Orchestrator(BaseAgent):
             elif current_task_status in [TaskStatus.EPIC_UPDATED, TaskStatus.SKIPPED]:
                 # Task is fully done or skipped, call TaskCompleter to mark it as completed
                 return TaskCompleter(self.state_manager, self.ui)
+
+        if not state.steps and not state.iterations:
+            # Ask the Developer to break down current task into actionable steps
+            return Developer(self.state_manager, self.ui)
 
         if state.current_step:
             # Execute next step in the task


### PR DESCRIPTION
Orchestrator needs to check task status before asking Developer to work on it, because the status may be "SKIPPED", in which case we don't wan to deal with the task at all.

Before the fix:
![Screenshot from 2024-05-30 11-39-31](https://github.com/Pythagora-io/gpt-pilot/assets/3362/89a94c59-27bf-4d7f-bd35-ab4fb9ba2018)

After the fix:
![Screenshot from 2024-05-30 11-42-26](https://github.com/Pythagora-io/gpt-pilot/assets/3362/45120cab-081c-4eb7-90f6-7c17cec0f0d5)
