### PR TITLE
don't send task progress on project load if there's no current task

### DIFF
--- a/core/state/state_manager.py
+++ b/core/state/state_manager.py
@@ -170,7 +170,6 @@ class StateManager:
         self.branch = state.branch
         self.project = state.branch.project
         self.next_state = await state.create_next_state()
-        # TODO: overwrite files?
         self.file_system = await self.init_file_system(load_existing=True)
         log.debug(
             f"Loaded project {self.project} ({self.project.id}) "
@@ -178,7 +177,7 @@ class StateManager:
             f"step {state.step_index} (state id={state.id})"
         )
 
-        if self.current_state.current_epic and self.ui:
+        if self.current_state.current_epic and self.current_state.current_task and self.ui:
             await self.ui.send_task_progress(
                 self.current_state.tasks.index(self.current_state.current_task) + 1,
                 len(self.current_state.tasks),


### PR DESCRIPTION
If we try to load to a state where a new feature is being planned, we'll have epics but won't have any tasks for the epic, and sending the task status to UI will crash:

![Screenshot from 2024-05-30 18-27-44](https://github.com/Pythagora-io/gpt-pilot/assets/3362/1bc6e93a-8837-4d81-9317-b6d15f52b2f2)
