### PR TITLE
ask user if they want to debug command errors

### DIFF
--- a/core/agents/error_handler.py
+++ b/core/agents/error_handler.py
@@ -74,6 +74,16 @@ class ErrorHandler(BaseAgent):
         if not cmd:
             raise ValueError("No command provided in command error response details")
 
+        confirm = await self.ask_question(
+            "Can I debug why this command failed?",
+            buttons={"yes": "Yes", "no": "No"},
+            default="yes",
+            buttons_only=True,
+        )
+        if confirm.cancelled or confirm.button == "no":
+            log.info("Skipping command error debug (requested by user)")
+            return AgentResponse.done(self)
+
         llm = self.get_llm()
         convo = AgentConvo(self).template(
             "debug",


### PR DESCRIPTION
We've improved error detection in commands but sometimes we still do it incorrectly, and sometimes the user has a reason why not to debug a command failure. So we (still) should ask them if they want to proceed with debugging it:

![Screenshot from 2024-06-04 08-54-43](https://github.com/Pythagora-io/gpt-pilot/assets/3362/64ddb61d-3b8e-4930-a983-637c58e308a2)
