### PR TITLE
correctly reset relevant_files after changing None/empty list semantics

### DIFF
--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -305,7 +305,7 @@ class Developer(BaseAgent):
 
         self.next_state.current_task["description"] = user_response.text
         self.next_state.current_task["run_always"] = True
-        self.next_state.relevant_files = []
+        self.next_state.relevant_files = None
         log.info(f"Task description updated to: {user_response.text}")
         # Orchestrator will rerun us with the new task description
         return False

--- a/core/agents/tech_lead.py
+++ b/core/agents/tech_lead.py
@@ -90,7 +90,7 @@ class TechLead(BaseAgent):
         )
         # Saving template files will fill this in and we want it clear for the
         # first task.
-        self.next_state.relevant_files = []
+        self.next_state.relevant_files = None
         return summary
 
     async def ask_for_new_feature(self) -> AgentResponse:

--- a/core/db/models/project_state.py
+++ b/core/db/models/project_state.py
@@ -254,7 +254,7 @@ class ProjectState(Base):
         self.set_current_task_status(TaskStatus.DONE)
         self.steps = []
         self.iterations = []
-        self.relevant_files = []
+        self.relevant_files = None
         self.modified_files = {}
         flag_modified(self, "tasks")
 


### PR DESCRIPTION
In https://github.com/Pythagora-io/gpt-pilot/pull/994 we changed how the check for relevant files works:

* `None` means we haven't checked for relevant files
* `[]` (empty list) means no files are relevant

This commit fixes the places in the code where we're resetting the relevant files value to trigger a new check.
