### PR TITLE
fix error message in case of missing Python packages

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,20 +6,23 @@ import sys
 
 try:
     from core.cli.main import run_pythagora
-except ImportError:
-    pythagora_root = os.path.dirname(os.path.dirname(__file__))
+except ImportError as err:
+    pythagora_root = os.path.dirname(__file__)
     venv_path = os.path.join(pythagora_root, "venv")
     requirements_path = os.path.join(pythagora_root, "requirements.txt")
     if sys.prefix == sys.base_prefix:
         venv_python_path = os.path.join(venv_path, "scripts" if sys.platform == "win32" else "bin", "python")
-        print("Python environment for Pythagora is not set up.", file=sys.stderr)
+        print(f"Python environment for Pythagora is not set up: module `{err.name}` is missing.", file=sys.stderr)
         print(f"Please create Python virtual environment: {sys.executable} -m venv {venv_path}", file=sys.stderr)
         print(
             f"Then install the required dependencies with: {venv_python_path} -m pip install -r {requirements_path}",
             file=sys.stderr,
         )
     else:
-        print("Python environment for Pythagora is not completely set up.", file=sys.stderr)
+        print(
+            f"Python environment for Pythagora is not completely set up: module `{err.name}` is missing",
+            file=sys.stderr,
+        )
         print(
             f"Please run `{sys.executable} -m pip install -r {requirements_path}` to finish Python setup, and rerun Pythagora.",
             file=sys.stderr,


### PR DESCRIPTION
This fixes the error message to:

* point to correct location of `requirements.txt`
* show the name of the package that's missing (in case people need to debug why exactly the import failed)

### Demo

Before (notice incorrect location for requirements.txt):

```bash
$ python3 main.py
Python environment for Pythagora is not set up.
Please create Python virtual environment: /usr/bin/python3 -m venv /home/senko/Projects/Pythagora/venv
Then install the required dependencies with: /home/senko/Projects/Pythagora/venv/bin/python -m pip install -r /home/senko/Projects/Pythagora/requirements.txt
```

Now (notice correct location, and reporting of exact package whose import failed):

```bash
$ python3 main.py
Python environment for Pythagora is not set up: module `pydantic` is missing.
Please create Python virtual environment: /usr/bin/python3 -m venv /home/senko/Projects/Pythagora/gpt-pilot/venv
Then install the required dependencies with: /home/senko/Projects/Pythagora/gpt-pilot/venv/bin/python -m pip install -r /home/senko/Projects/Pythagora/gpt-pilot/requirements.txt
```
