### PR TITLE
Handle case where LLM pics invalid docset.

### DIFF
--- a/core/agents/external_docs.py
+++ b/core/agents/external_docs.py
@@ -92,7 +92,7 @@ class ExternalDocumentation(BaseAgent):
         await self.send_message("Determining if external documentation is needed for the next task...")
         llm_response: SelectedDocsets = await llm(convo, parser=JSONParser(spec=SelectedDocsets))
         available_docsets = dict(available_docsets)
-        return {k: available_docsets[k] for k in llm_response.docsets}
+        return {k: available_docsets[k] for k in llm_response.docsets if k in available_docsets}
 
     async def _create_queries(self, docsets: dict[str, str]) -> dict[str, list[str]]:
         """Return queries we have to make to the docs API.

--- a/core/prompts/external-docs/select_docset.prompt
+++ b/core/prompts/external-docs/select_docset.prompt
@@ -12,4 +12,4 @@ Here is the list of available documentations:
 {{ docset[0], docset[1] }}
 {% endfor %}
 
-Now, give me the list of the additional documentation that you would like to use to complete the task listed above. Return only the documentation that is absolutely required for the given task. If there is no additional documentation in the list that you would like to use, return an empty list.
+Now, give me the list of the additional documentation that you would like to use to complete the task listed above. Return only the documentation that is absolutely required for the given task, and only from the list of available documentations provided above. If there is no additional documentation in the list that you would like to use, return an empty list.

--- a/tests/agents/test_external_docs.py
+++ b/tests/agents/test_external_docs.py
@@ -22,6 +22,21 @@ async def test_stores_documentation_snippets_for_task(agentcontext):
 
 
 @pytest.mark.asyncio
+async def test_continues_without_docs_for_invalid_docset(agentcontext):
+    sm, _, ui, mock_llm = agentcontext
+
+    sm.current_state.tasks = [{"description": "Some VueJS task", "status": "todo"}]
+    await sm.commit()
+
+    ed = ExternalDocumentation(sm, ui)
+    ed.get_llm = mock_llm(
+        side_effect=[SelectedDocsets(docsets=["doesnt-exist"]), DocQueries(queries=["VueJS component model"])]
+    )
+    await ed.run()
+    assert ed.next_state.docs == []
+
+
+@pytest.mark.asyncio
 async def test_continues_without_docs_if_api_is_down(agentcontext):
     sm, _, ui, _ = agentcontext
 


### PR DESCRIPTION
Fixes an issue where LLM would select a docset that doesn't exist.

This handles that in 2 ways:
- improve the prompt to tell the LLM to select only from the provided list
- if an invalid docset is still picked, continue without that docset