### PR TITLE
parse_task: convince GPT4 to not try to output file contents

### DIFF
--- a/core/prompts/developer/parse_task.prompt
+++ b/core/prompts/developer/parse_task.prompt
@@ -5,7 +5,7 @@ when converting this message to steps.
 Each step can be either:
 
 * `command` - command to run (must be able to run on a {{ os }} machine, assume current working directory is project root folder)
-* `save_file` - create or update ONE file
+* `save_file` - create or update ONE file (only provide file path, not contents)
 * `human_intervention` - if you need the human to do something, use this type of step and explain in details what you want the human to do. NEVER use `human_intervention` for testing, as testing will be done separately by a dedicated QA after all the steps are done. Also you MUST NOT use `human_intervention` to ask the human to write or review code.
 
 **IMPORTANT**: If multiple changes are required for same file, you must provide single `save_file` step for each file.


### PR DESCRIPTION
GPT4 likes to output file content in parse task output, even though it's not asked for, so we must be more specific about NOT including file content.
