### PR TITLE
Code monkey in iteration

### DIFF
--- a/core/llm/base.py
+++ b/core/llm/base.py
@@ -201,7 +201,7 @@ class BaseLLMClient:
                 request_log.error = str(f"Read timeout: {err}")
                 request_log.status = LLMRequestStatus.ERROR
                 continue
-            except httpx.ReadError as err:
+            except (httpx.ReadError, httpx.RemoteProtocolError) as err:
                 log.warning(f"Read error: {err}", exc_info=True)
                 request_log.error = str(f"Read error: {err}")
                 request_log.status = LLMRequestStatus.ERROR


### PR DESCRIPTION
CodeMonkey prompt references a previous message which is either task breakdown or iteration, but we've previously always appended the task convo. Now, if a file is changed based on the iteration instructions, the correct prompt template is used

Prompts in LLM request log in database:

![Screenshot from 2024-06-12 14-46-30](https://github.com/Pythagora-io/gpt-pilot/assets/3362/69b890ed-352d-4de0-ae1b-ed23984b5493)

Also, a tiny fix for yet another variant of API error that we want to catch and handle.