### PR TITLE
code block parser: only consider triple-backticks if at start of line

### DIFF
--- a/core/llm/parser.py
+++ b/core/llm/parser.py
@@ -35,8 +35,7 @@ class MultiCodeBlockParser:
     """
 
     def __init__(self):
-        # FIXME: ``` should be the only content on the line`
-        self.pattern = re.compile(r"```([a-z0-9]+\n)?(.*?)```\s*", re.DOTALL)
+        self.pattern = re.compile(r"^```([a-z0-9]+\n)?(.*?)^```\s*", re.DOTALL | re.MULTILINE)
 
     def __call__(self, text: str) -> list[str]:
         blocks = []

--- a/tests/llm/test_parser.py
+++ b/tests/llm/test_parser.py
@@ -15,6 +15,7 @@ from core.llm.parser import CodeBlockParser, EnumParser, JSONParser, MultiCodeBl
         ("```\n```", [""]),
         ("```py\n```", [""]),
         ("```py\nsome code\n```", ["some code"]),
+        ("```py\nsome ``` code\n```", ["some ``` code"]),
         (
             "some text preamble\n" "```\nsome code\n```\n" "```py\nmore\ncode\n```\n" "some text conclusion",
             ["some code", "more\ncode"],
@@ -49,7 +50,7 @@ def test_code_block_parser(input, expected):
     [
         ("{}", True, {}),
         ('{"a": 1}', True, {"a": 1}),
-        ('```json\n{"a": 1, "b": "c"}```', True, {"a": 1, "b": "c"}),
+        ('```json\n{"a": 1, "b": "c"}\n```', True, {"a": 1, "b": "c"}),
         ("", True, ValueError),
         ("", False, None),
         ("{bad json}", True, ValueError),
@@ -85,7 +86,7 @@ def test_parse_json_no_spec(input, strict, expected):
             },
         ),
         (
-            '```{"name": "John", "children": [{"age": 1, "name": "Jane", "geo": [1.0, 2.0]}]}```',
+            '```\n{"name": "John", "children": [{"age": 1, "name": "Jane", "geo": [1.0, 2.0]}]}\n```',
             {
                 "name": "John",
                 "children": [


### PR DESCRIPTION
Don't treat triple-backticks as block start/end unless they're at the start of the line.

## Demo:

![Screenshot from 2024-06-20 10-53-24](https://github.com/Pythagora-io/gpt-pilot/assets/3362/b2e925ab-3238-42ad-a755-c10671db00e4)
