### PR TITLE
Only check for docs if the user wants to run the task.

### DIFF
--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -8,6 +8,7 @@ from core.agents.base import BaseAgent
 from core.agents.convo import AgentConvo
 from core.agents.response import AgentResponse, ResponseType
 from core.db.models.project_state import TaskStatus
+from core.db.models.specification import Complexity
 from core.llm.parser import JSONParser
 from core.log import get_logger
 from core.telemetry import telemetry
@@ -77,9 +78,16 @@ class Developer(BaseAgent):
 
         # By default, we want to ask the user if they want to run the task,
         # except in certain cases (such as they've just edited it).
-        if not self.current_state.current_task.get("run_always", False):
+        # The check for docs is here to prevent us from asking the user whether we should
+        # run the task twice - we'll only ask if we haven't yet checked for docs.
+        if not self.current_state.current_task.get("run_always", False) and self.current_state.docs is None:
             if not await self.ask_to_execute_task():
                 return AgentResponse.done(self)
+
+        if self.current_state.docs is None and self.current_state.specification.complexity != Complexity.SIMPLE:
+            # We check for external docs here, to make sure we only fetch the docs
+            # if the task is actually being done.
+            return AgentResponse.external_docs_required(self)
 
         return await self.breakdown_current_task()
 
@@ -204,6 +212,12 @@ class Developer(BaseAgent):
             },
         )
         return AgentResponse.done(self)
+
+    async def get_external_docs(self):
+        # TODO: hook into external docs here
+        # TODO: make sure to add the docs both in current_state (so it can be used right)
+        # away in the task breakdown, and next_state, so it's stored in the database
+        pass
 
     async def get_relevant_files(
         self, user_feedback: Optional[str] = None, solution_description: Optional[str] = None

--- a/core/agents/developer.py
+++ b/core/agents/developer.py
@@ -213,12 +213,6 @@ class Developer(BaseAgent):
         )
         return AgentResponse.done(self)
 
-    async def get_external_docs(self):
-        # TODO: hook into external docs here
-        # TODO: make sure to add the docs both in current_state (so it can be used right)
-        # away in the task breakdown, and next_state, so it's stored in the database
-        pass
-
     async def get_relevant_files(
         self, user_feedback: Optional[str] = None, solution_description: Optional[str] = None
     ) -> AgentResponse:

--- a/core/agents/orchestrator.py
+++ b/core/agents/orchestrator.py
@@ -19,7 +19,6 @@ from core.agents.tech_lead import TechLead
 from core.agents.tech_writer import TechnicalWriter
 from core.agents.troubleshooter import Troubleshooter
 from core.db.models.project_state import TaskStatus
-from core.db.models.specification import Complexity
 from core.log import get_logger
 from core.telemetry import telemetry
 from core.ui.base import ProjectStage
@@ -180,6 +179,8 @@ class Orchestrator(BaseAgent):
                 return Developer(self.state_manager, self.ui, prev_response=prev_response)
             if prev_response.type == ResponseType.IMPORT_PROJECT:
                 return Importer(self.state_manager, self.ui, prev_response=prev_response)
+            if prev_response.type == ResponseType.EXTERNAL_DOCS_REQUIRED:
+                return ExternalDocumentation(self.state_manager, self.ui, prev_response=prev_response)
 
         if not state.specification.description:
             if state.files:
@@ -198,9 +199,6 @@ class Orchestrator(BaseAgent):
         ):
             # Ask the Tech Lead to break down the initial project or feature into tasks and apply project templates
             return TechLead(self.state_manager, self.ui, process_manager=self.process_manager)
-
-        if state.current_task and state.docs is None and state.specification.complexity != Complexity.SIMPLE:
-            return ExternalDocumentation(self.state_manager, self.ui)
 
         # Current task status must be checked before Developer is called because we might want
         # to skip it instead of breaking it down

--- a/core/agents/response.py
+++ b/core/agents/response.py
@@ -42,6 +42,9 @@ class ResponseType(str, Enum):
     IMPORT_PROJECT = "import-project"
     """User wants to import an existing project."""
 
+    EXTERNAL_DOCS_REQUIRED = "external-docs-required"
+    """We need to fetch external docs for a task."""
+
 
 class AgentResponse:
     type: ResponseType = ResponseType.DONE
@@ -137,3 +140,7 @@ class AgentResponse:
     @staticmethod
     def import_project(agent: "BaseAgent") -> "AgentResponse":
         return AgentResponse(type=ResponseType.IMPORT_PROJECT, agent=agent)
+
+    @staticmethod
+    def external_docs_required(agent: "BaseAgent") -> "AgentResponse":
+        return AgentResponse(type=ResponseType.EXTERNAL_DOCS_REQUIRED, agent=agent)


### PR DESCRIPTION
We want to fetch external docs only if the user wants to execute the task (not for skipped  tasks).

This is not ideal implementation, as it's not intuitive in the `Developer` agent when we check for docs, but I think it's better than the alternative.

Initially, I wanted to move the external docs check into `Developer` agent, sort of like what `get_relevant_files` does, but gave up, as that would clobber the `Developer` quite a lot - external docs is much more complex, does 2 LLM requests and 2 API requests.

The complexity arises from the fact how control flow is done between agents, which is through `AgentResponse`, and a bunch of checks in `Orchestrator` and various agents. I'm open to suggestions on how to make this better.