### PR TITLE
process manager: fix getting command output

### DIFF
--- a/core/proc/process_manager.py
+++ b/core/proc/process_manager.py
@@ -90,11 +90,15 @@ class LocalProcess:
         :param timeout: Timeout for the read operation (should not be too long).
         :return: Data read from the stream reader, or empty string.
         """
-        try:
-            data = await asyncio.wait_for(reader.read(), timeout)
-            return data.decode("utf-8", errors="ignore")
-        except asyncio.TimeoutError:
-            return ""
+        buffer = ""
+        while True:
+            try:
+                data = await asyncio.wait_for(reader.read(1), timeout)
+                if not data:
+                    return buffer
+                buffer += data.decode("utf-8", errors="ignore")
+            except asyncio.TimeoutError:
+                return buffer
 
     async def read_output(self, timeout: float = NONBLOCK_READ_TIMEOUT) -> tuple[str, str]:
         new_stdout = await self._nonblock_read(self._process.stdout, timeout)


### PR DESCRIPTION
This works around asyncio reads not having a "read available" function. Timing out a read won't return incomplete (available) output, so the workaround is to read character by character for as long as we can.

## Demo

[Screencast from 2024-07-04 16-37-54.webm](https://github.com/Pythagora-io/gpt-pilot/assets/3362/35356379-1d36-434a-86ed-183acea5dc72)

