### PR TITLE
Print each task on its own line in filter_files.

### DIFF
--- a/core/prompts/developer/filter_files.prompt
+++ b/core/prompts/developer/filter_files.prompt
@@ -8,6 +8,7 @@ We've broken the development of the project down to these tasks:
 ```
 {% for task in state.tasks %}
 {{ loop.index }}. {{ task.description }}{% if task.get("status") == "done" %} (completed){% endif %}
+
 {% endfor %}
 ```
 


### PR DESCRIPTION
Currently, they are all printed in a single line.