### PR TITLE
Use template summary in project details when templates are used

### DIFF
--- a/core/prompts/partials/project_details.prompt
+++ b/core/prompts/partials/project_details.prompt
@@ -20,3 +20,7 @@ Here are the technologies that should be used for this project:
 * {{ tech.name }} - {{ tech.description }}
 {% endfor %}
 {% endif %}
+{% if state.specification.template_summary %}
+
+{{ state.specification.template_summary }}
+{% endif %}

--- a/core/templates/registry.py
+++ b/core/templates/registry.py
@@ -4,8 +4,7 @@ from core.log import get_logger
 
 from .javascript_react import JavascriptReactProjectTemplate
 from .node_express_mongoose import NodeExpressMongooseProjectTemplate
-
-# from .react_express import ReactExpressProjectTemplate
+from .react_express import ReactExpressProjectTemplate
 
 log = get_logger(__name__)
 
@@ -15,11 +14,11 @@ class ProjectTemplateEnum(str, Enum):
 
     JAVASCRIPT_REACT = JavascriptReactProjectTemplate.name
     NODE_EXPRESS_MONGOOSE = NodeExpressMongooseProjectTemplate.name
-    # REACT_EXPRESS = ReactExpressProjectTemplate.name
+    REACT_EXPRESS = ReactExpressProjectTemplate.name
 
 
 PROJECT_TEMPLATES = {
     JavascriptReactProjectTemplate.name: JavascriptReactProjectTemplate,
     NodeExpressMongooseProjectTemplate.name: NodeExpressMongooseProjectTemplate,
-    # ReactExpressProjectTemplate.name: ReactExpressProjectTemplate,
+    ReactExpressProjectTemplate.name: ReactExpressProjectTemplate,
 }

--- a/tests/templates/test_templates.py
+++ b/tests/templates/test_templates.py
@@ -6,7 +6,6 @@ from core.state.state_manager import StateManager
 from core.templates.registry import PROJECT_TEMPLATES
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @patch("core.state.state_manager.get_config")
 async def test_render_react_express_sql(mock_get_config, testmanager):
@@ -31,7 +30,6 @@ async def test_render_react_express_sql(mock_get_config, testmanager):
     assert "api/models/user.js" not in files
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @patch("core.state.state_manager.get_config")
 async def test_render_react_express_nosql(mock_get_config, testmanager):
@@ -57,7 +55,6 @@ async def test_render_react_express_nosql(mock_get_config, testmanager):
     assert "prisma/schema.prisma" not in files
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 @patch("core.state.state_manager.get_config")
 async def test_render_javascript_react(mock_get_config, testmanager):


### PR DESCRIPTION
The template summary contains information about what's already implemented so leaving it out, the LLM doesn't know what it doesn't need to implement.
