### PR TITLE
Template fixes

### DIFF
--- a/core/agents/spec_writer.py
+++ b/core/agents/spec_writer.py
@@ -76,6 +76,8 @@ class SpecWriter(BaseAgent):
         if len(user_description) < ANALYZE_THRESHOLD and complexity != Complexity.SIMPLE:
             initial_spec = await self.analyze_spec(user_description)
             reviewed_spec = await self.review_spec(desc=user_description, spec=initial_spec)
+        else:
+            initial_spec = reviewed_spec = user_description
 
         self.next_state.specification = self.current_state.specification.clone()
         self.next_state.specification.original_description = user_description

--- a/core/templates/registry.py
+++ b/core/templates/registry.py
@@ -4,8 +4,7 @@ from core.log import get_logger
 
 from .javascript_react import JavascriptReactProjectTemplate
 from .node_express_mongoose import NodeExpressMongooseProjectTemplate
-
-# from .react_express import ReactExpressProjectTemplate
+from .react_express import ReactExpressProjectTemplate
 
 log = get_logger(__name__)
 
@@ -15,11 +14,11 @@ class ProjectTemplateEnum(str, Enum):
 
     JAVASCRIPT_REACT = JavascriptReactProjectTemplate.name
     NODE_EXPRESS_MONGOOSE = NodeExpressMongooseProjectTemplate.name
-    # REACT_EXPRESS = ReactExpressProjectTemplate.name
+    REACT_EXPRESS = ReactExpressProjectTemplate.name
 
 
 PROJECT_TEMPLATES = {
     JavascriptReactProjectTemplate.name: JavascriptReactProjectTemplate,
     NodeExpressMongooseProjectTemplate.name: NodeExpressMongooseProjectTemplate,
-    # ReactExpressProjectTemplate.name: ReactExpressProjectTemplate,
+    ReactExpressProjectTemplate.name: ReactExpressProjectTemplate,
 }

--- a/core/templates/tree/react_express/api/app.js
+++ b/core/templates/tree/react_express/api/app.js
@@ -28,8 +28,8 @@ app.use(cors());
 {% if options.auth %}
 
 // Authentication routes
-app.use(authRoutes);
 app.use(authenticateWithToken);
+app.use(authRoutes);
 {% endif %}
 
 app.use(apiRoutes);

--- a/core/templates/tree/react_express/api/routes/authRoutes.js
+++ b/core/templates/tree/react_express/api/routes/authRoutes.js
@@ -61,4 +61,8 @@ router.post('/api/auth/password', requireUser, async (req, res) => {
   res.status(204).send();
 });
 
+router.get('/api/auth/me', requireUser, async (req, res) => {
+  return res.status(200).json(req.user);
+});
+
 export default router;

--- a/core/templates/tree/react_express/ui/main.jsx
+++ b/core/templates/tree/react_express/ui/main.jsx
@@ -1,3 +1,6 @@
+{% if options.auth %}
+import axios from 'axios'
+{% endif %}
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider, useLocation } from "react-router-dom"
@@ -9,6 +12,15 @@ import Home from './pages/Home.jsx'
 {% if options.auth %}
 import Register from './pages/Register.jsx'
 import Login from './pages/Login.jsx'
+
+// Add auth token to every API request if we have it
+axios.interceptors.request.use(config => {
+  const token = localStorage.getItem("token");
+  if (token && !config.headers.Authorization) {
+    config.headers.Authorization = `Token ${token}`
+  }
+  return config
+})
 {% endif %}
 
 function PageNotFound() {


### PR DESCRIPTION
This modifies the React+Express template to inject authentication headers in all client API calls.

This is so the LLM doesn't need to remember to add a header for each request manually, which is not reliable.

The PR also has a fix for a bug (incorrect variable initialization) in the SpecWriter agent that blocked me from doing the templating change.

The last commit re-enables the template again. Ideally the PR will be QAd before merging/releasing.

