### PR TITLE
Adding llm provider to set when is checked to not repeat the same check

### DIFF
--- a/core/cli/main.py
+++ b/core/cli/main.py
@@ -88,6 +88,7 @@ async def llm_api_check(ui: UIBase) -> bool:
                 log.warning(f"API check for {llm_config.provider.value} failed.")
             else:
                 log.info(f"API check for {llm_config.provider.value} succeeded.")
+                checked_llms.add(llm_config.provider)
         except APIError as err:
             await ui.send_message(
                 f"API check for {llm_config.provider.value} failed with: {err}",


### PR DESCRIPTION
The function llm_api_check inside core\cli\main.py checks if the configured LLMs are reachable.
As some LLM could be repeated in the configuration, there is a set variable to check if the LLM was already checked, but inside the for loop, the code never add the LLM to the set when is checked.
The last line is what I'm adding in this PR

```python
    checked_llms: set[LLMProvider] = set()
    for llm_config in config.all_llms():
        if llm_config.provider in checked_llms:
            continue

        client_class = BaseLLMClient.for_provider(llm_config.provider)
        llm_client = client_class(llm_config, stream_handler=handler, error_handler=handler)
        try:
            resp = await llm_client.api_check()
            if not resp:
                success = False
                log.warning(f"API check for {llm_config.provider.value} failed.")
            else:
                log.info(f"API check for {llm_config.provider.value} succeeded.")
                checked_llms.add(llm_config.provider)
```
