### PR TITLE
fix: remove broken Docker TOC link with no corresponding section

### DIFF
--- a/.github/workflows/cloud-staging-build.yaml
+++ b/.github/workflows/cloud-staging-build.yaml
@@ -118,8 +118,6 @@ jobs:
       - name: Setup extension
         run: |
           cd tmp_extension
-          npm install
-          npm run compile:ts
           npm install -g @vscode/vsce@3.3.2
           npm run build
           vsce package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-#  (2025-08-18)
+#  (2025-08-25)
+
+
+### Reverts
+
+* Revert "Implemented weekend discount" ([734e0c7](https://github.com/Pythagora-io/pythagora-v1/commit/734e0c726b179a45f235a0fd230a6310c77ae740))
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <div align="center">
 
-[![Discord Follow](https://dcbadge.vercel.app/api/server/HaqXugmxr9?style=flat)](https://discord.gg/HaqXugmxr9)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2?style=social&logo=discord)](https://discord.gg/HaqXugmxr9)
 [![GitHub Repo stars](https://img.shields.io/github/stars/Pythagora-io/gpt-pilot?style=social)](https://github.com/Pythagora-io/gpt-pilot)
-[![Twitter Follow](https://img.shields.io/twitter/follow/HiPythagora?style=social)](https://twitter.com/HiPythagora)
+[![Twitter Follow](https://img.shields.io/twitter/follow/PythagoraAI?style=social)](https://x.com/PythagoraAI)
 
 </div>
 
@@ -28,17 +28,25 @@
 <br>
 
 <div align="center">
-
+   
 ### GPT Pilot doesn't just generate code, it builds apps!
 
 </div>
 
+<div align="center">
+
+This repo is not being maintained anymore.
+
+# Visit [Pythagora.ai](https://www.pythagora.ai/) for more info
+
+</div>
+
 ---
 <div align="center">
 
-[![See it in action](https://i3.ytimg.com/vi/4g-1cPGK0GA/maxresdefault.jpg)](https://youtu.be/4g-1cPGK0GA)
+[![See it in action](https://img.youtube.com/vi/o1nEvwjKziw/0.jpg)]([https://youtu.be/4g-1cPGK0GA](https://www.youtube.com/watch?v=o1nEvwjKziw))
 
-(click to open the video in YouTube) (1:40min)
+(click to open the video in YouTube) (1:04min)
 
 </div>
 
@@ -46,11 +54,11 @@
 
 <div align="center">
 
-<a href="vscode:extension/PythagoraTechnologies.gpt-pilot-vs-code" target="_blank"><img src="https://github.com/Pythagora-io/gpt-pilot/assets/10895136/5792143e-77c7-47dd-ad96-6902be1501cd" alt="Pythagora-io%2Fgpt-pilot | Trendshift" style="width: 185px; height: 55px;" width="185" height="55"/></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=PythagoraTechnologies.pythagora-vs-code" target="_blank"><img src="https://github.com/Pythagora-io/gpt-pilot/assets/10895136/5792143e-77c7-47dd-ad96-6902be1501cd" alt="Pythagora-io%2Fgpt-pilot | Trendshift" style="width: 185px; height: 55px;" width="185" height="55"/></a>
 
 </div>
 
-GPT Pilot is the core technology for the [Pythagora VS Code extension](https://bit.ly/3IeZxp6) that aims to provide **the first real AI developer companion**. Not just an autocomplete or a helper for PR messages but rather a real AI developer that can write full features, debug them, talk to you about issues, ask for review, etc.
+GPT Pilot is the core technology for the [Pythagora VS Code extension](https://marketplace.visualstudio.com/items?itemName=PythagoraTechnologies.pythagora-vs-code) that aims to provide **the first real AI developer companion**. Not just an autocomplete or a helper for PR messages but rather a real AI developer that can write full features, debug them, talk to you about issues, ask for review, etc.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ GPT Pilot is the core technology for the [Pythagora VS Code extension](https://m
 * [🔌 Requirements](#-requirements)
 * [🚦How to start using gpt-pilot?](#how-to-start-using-gpt-pilot)
 * [🔎 Examples](#-examples)
-* [🐳 How to start gpt-pilot in docker?](#-how-to-start-gpt-pilot-in-docker)
 * [🧑‍💻️ CLI arguments](#-cli-arguments)
 * [🏗 How GPT Pilot works?](#-how-gpt-pilot-works)
 * [🕴How's GPT Pilot different from _Smol developer_ and _GPT engineer_?](#hows-gpt-pilot-different-from-smol-developer-and-gpt-engineer)

--- a/core/agents/frontend.py
+++ b/core/agents/frontend.py
@@ -25,7 +25,7 @@ from core.llm.convo import Convo
 from core.llm.parser import DescriptiveCodeBlockParser, OptionalCodeBlockParser
 from core.log import get_logger
 from core.telemetry import telemetry
-from core.ui.base import ProjectStage, UISource
+from core.ui.base import ProjectStage
 
 log = get_logger(__name__)
 
@@ -168,10 +168,6 @@ class Frontend(FileDiffMixin, GitMixin, BaseAgent):
         if user_input:
             await self.send_message("Errors detected, fixing...")
         else:
-            await self.ui.send_message(
-                "Use code CODE20 and subscribe https://pythagora.ai/pricing",
-                source=UISource("Congratulations", "success"),
-            )
             answer = await self.ask_question(
                 "Do you want to change anything or report a bug?" if frontend_only else FE_CHANGE_REQ,
                 buttons={"yes": "I'm done building the UI"} if not frontend_only else None,

--- a/core/agents/spec_writer.py
+++ b/core/agents/spec_writer.py
@@ -11,7 +11,7 @@ from core.llm.parser import StringParser
 from core.log import get_logger
 from core.telemetry import telemetry
 from core.templates.registry import PROJECT_TEMPLATES
-from core.ui.base import ProjectStage, UISource
+from core.ui.base import ProjectStage
 
 log = get_logger(__name__)
 
@@ -122,9 +122,6 @@ class SpecWriter(BaseAgent):
 
         await self.ui.send_front_logs_headers("specs_0", ["E1 / T1", "Writing Specification", "working"], "")
 
-        await self.ui.send_message(
-            "Use code CODE20 and subscribe https://pythagora.ai/pricing", source=UISource("Congratulations", "success")
-        )
         await self.send_message(
             "## Write specification\n\nPythagora is generating a detailed specification for app based on your input.",
             # project_state_id="setup",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pythagora-core"
-version = "2.0.9"
+version = "2.0.10"
 description = "Build complete apps using AI agents"
 authors = ["Leon Ostrez <leon@pythagora.ai>"]
 license = "FSL-1.1-MIT"


### PR DESCRIPTION
Fixes #1107

## Problem

The table of contents in `README.md` contains a link to a "🐳 How to start gpt-pilot in docker?" section that does not exist in the document. Docker Compose support was available in the [version-0.1 branch](https://github.com/Pythagora-io/gpt-pilot/tree/version-0.1) but was not carried forward to the current version, leaving a dangling TOC entry that leads nowhere.

Users following the TOC click the link and find no corresponding section, as reported in #1107.

## Solution

Remove the broken `🐳 How to start gpt-pilot in docker?` entry from the table of contents.

## Testing

Verified that the TOC no longer contains the orphaned Docker link and all remaining TOC entries resolve to existing sections in the document.