### PR TITLE
fix: correct type comparison in rate_limit_sleep causing excessive sleep on TPM rate limit

### DIFF
--- a/.github/workflows/cloud-staging-build.yaml
+++ b/.github/workflows/cloud-staging-build.yaml
@@ -118,8 +118,6 @@ jobs:
       - name: Setup extension
         run: |
           cd tmp_extension
-          npm install
-          npm run compile:ts
           npm install -g @vscode/vsce@3.3.2
           npm run build
           vsce package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-#  (2025-08-18)
+#  (2025-08-25)
+
+
+### Reverts
+
+* Revert "Implemented weekend discount" ([734e0c7](https://github.com/Pythagora-io/pythagora-v1/commit/734e0c726b179a45f235a0fd230a6310c77ae740))
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <div align="center">
 
-[![Discord Follow](https://dcbadge.vercel.app/api/server/HaqXugmxr9?style=flat)](https://discord.gg/HaqXugmxr9)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2?style=social&logo=discord)](https://discord.gg/HaqXugmxr9)
 [![GitHub Repo stars](https://img.shields.io/github/stars/Pythagora-io/gpt-pilot?style=social)](https://github.com/Pythagora-io/gpt-pilot)
-[![Twitter Follow](https://img.shields.io/twitter/follow/HiPythagora?style=social)](https://twitter.com/HiPythagora)
+[![Twitter Follow](https://img.shields.io/twitter/follow/PythagoraAI?style=social)](https://x.com/PythagoraAI)
 
 </div>
 
@@ -28,17 +28,25 @@
 <br>
 
 <div align="center">
-
+   
 ### GPT Pilot doesn't just generate code, it builds apps!
 
 </div>
 
+<div align="center">
+
+This repo is not being maintained anymore.
+
+# Visit [Pythagora.ai](https://www.pythagora.ai/) for more info
+
+</div>
+
 ---
 <div align="center">
 
-[![See it in action](https://i3.ytimg.com/vi/4g-1cPGK0GA/maxresdefault.jpg)](https://youtu.be/4g-1cPGK0GA)
+[![See it in action](https://img.youtube.com/vi/o1nEvwjKziw/0.jpg)]([https://youtu.be/4g-1cPGK0GA](https://www.youtube.com/watch?v=o1nEvwjKziw))
 
-(click to open the video in YouTube) (1:40min)
+(click to open the video in YouTube) (1:04min)
 
 </div>
 
@@ -46,11 +54,11 @@
 
 <div align="center">
 
-<a href="vscode:extension/PythagoraTechnologies.gpt-pilot-vs-code" target="_blank"><img src="https://github.com/Pythagora-io/gpt-pilot/assets/10895136/5792143e-77c7-47dd-ad96-6902be1501cd" alt="Pythagora-io%2Fgpt-pilot | Trendshift" style="width: 185px; height: 55px;" width="185" height="55"/></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=PythagoraTechnologies.pythagora-vs-code" target="_blank"><img src="https://github.com/Pythagora-io/gpt-pilot/assets/10895136/5792143e-77c7-47dd-ad96-6902be1501cd" alt="Pythagora-io%2Fgpt-pilot | Trendshift" style="width: 185px; height: 55px;" width="185" height="55"/></a>
 
 </div>
 
-GPT Pilot is the core technology for the [Pythagora VS Code extension](https://bit.ly/3IeZxp6) that aims to provide **the first real AI developer companion**. Not just an autocomplete or a helper for PR messages but rather a real AI developer that can write full features, debug them, talk to you about issues, ask for review, etc.
+GPT Pilot is the core technology for the [Pythagora VS Code extension](https://marketplace.visualstudio.com/items?itemName=PythagoraTechnologies.pythagora-vs-code) that aims to provide **the first real AI developer companion**. Not just an autocomplete or a helper for PR messages but rather a real AI developer that can write full features, debug them, talk to you about issues, ask for review, etc.
 
 ---
 

--- a/core/agents/frontend.py
+++ b/core/agents/frontend.py
@@ -25,7 +25,7 @@ from core.llm.convo import Convo
 from core.llm.parser import DescriptiveCodeBlockParser, OptionalCodeBlockParser
 from core.log import get_logger
 from core.telemetry import telemetry
-from core.ui.base import ProjectStage, UISource
+from core.ui.base import ProjectStage
 
 log = get_logger(__name__)
 
@@ -168,10 +168,6 @@ class Frontend(FileDiffMixin, GitMixin, BaseAgent):
         if user_input:
             await self.send_message("Errors detected, fixing...")
         else:
-            await self.ui.send_message(
-                "Use code CODE20 and subscribe https://pythagora.ai/pricing",
-                source=UISource("Congratulations", "success"),
-            )
             answer = await self.ask_question(
                 "Do you want to change anything or report a bug?" if frontend_only else FE_CHANGE_REQ,
                 buttons={"yes": "I'm done building the UI"} if not frontend_only else None,

--- a/core/agents/spec_writer.py
+++ b/core/agents/spec_writer.py
@@ -11,7 +11,7 @@ from core.llm.parser import StringParser
 from core.log import get_logger
 from core.telemetry import telemetry
 from core.templates.registry import PROJECT_TEMPLATES
-from core.ui.base import ProjectStage, UISource
+from core.ui.base import ProjectStage
 
 log = get_logger(__name__)
 
@@ -122,9 +122,6 @@ class SpecWriter(BaseAgent):
 
         await self.ui.send_front_logs_headers("specs_0", ["E1 / T1", "Writing Specification", "working"], "")
 
-        await self.ui.send_message(
-            "Use code CODE20 and subscribe https://pythagora.ai/pricing", source=UISource("Congratulations", "success")
-        )
         await self.send_message(
             "## Write specification\n\nPythagora is generating a detailed specification for app based on your input.",
             # project_state_id="setup",

--- a/core/llm/openai_client.py
+++ b/core/llm/openai_client.py
@@ -99,7 +99,7 @@ class OpenAIClient(BaseLLMClient):
 
         remaining_tokens = headers["x-ratelimit-remaining-tokens"]
         time_regex = r"(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?"
-        if remaining_tokens == 0:
+        if int(remaining_tokens) == 0:
             match = re.search(time_regex, headers["x-ratelimit-reset-tokens"])
         else:
             match = re.search(time_regex, headers["x-ratelimit-reset-requests"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pythagora-core"
-version = "2.0.9"
+version = "2.0.10"
 description = "Build complete apps using AI agents"
 authors = ["Leon Ostrez <leon@pythagora.ai>"]
 license = "FSL-1.1-MIT"


### PR DESCRIPTION
Fixes #1121

## Problem

When OpenAI returns a 429 rate limit error due to tokens-per-minute (TPM) exhaustion, GPT Pilot sleeps for an excessively long time (commonly 7200 or 9600 seconds) instead of the short wait time indicated in the API response (e.g. 11 seconds).

**Root cause:** In `core/llm/openai_client.py`, the `rate_limit_sleep` method reads the `x-ratelimit-remaining-tokens` response header as a string, then compares it to the integer `0`:

```python
remaining_tokens = headers["x-ratelimit-remaining-tokens"]  # str, e.g. "0"
if remaining_tokens == 0:   # always False — str != int
    match = re.search(time_regex, headers["x-ratelimit-reset-tokens"])
else:
    match = re.search(time_regex, headers["x-ratelimit-reset-requests"])
```

Because `"0" == 0` is always `False`, the code **never** reads `x-ratelimit-reset-tokens` (which holds the short per-minute token reset time). It always reads `x-ratelimit-reset-requests` instead, which can be set to a much longer duration (e.g. 2 hours = 7200 s) when the requests-per-day limit is the binding constraint.

## Solution

Cast `remaining_tokens` to `int` before the comparison:

```python
if int(remaining_tokens) == 0:
```

This ensures that when token usage is at the limit, the code correctly reads `x-ratelimit-reset-tokens` (the short, per-minute reset time) rather than `x-ratelimit-reset-requests`.

## Testing

Manually reviewed the logic. The fix is a one-character type cast that makes the comparison semantically correct and matches the documented OpenAI rate limit header behavior.