### PR TITLE
fix: bump requests pin to 2.32.4 to address CVE-2024-47081 (fixes #1184)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pydantic==2.8.2
 python-dotenv==1.0.1
 pyyaml==6.0.2
 regex==2024.11.6
-requests==2.32.3
+requests==2.32.4
 sniffio==1.3.1
 sqlalchemy==2.0.32
 sqlalchemy[asyncio]==2.0.32

--- a/tests/test_requests_cve_1184.py
+++ b/tests/test_requests_cve_1184.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Regression test for CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7).
+
+requests < 2.32.4 can leak .netrc credentials to a different host when it
+follows a redirect to a URL carrying userinfo. The pinned dependency set in
+requirements.txt must never resolve to an affected requests version.
+
+See https://github.com/Pythagora-io/gpt-pilot/issues/1184
+
+Runnable two ways:
+  * as a standalone script:  python3 tests/test_requests_cve_1184.py
+  * under pytest:            pytest tests/test_requests_cve_1184.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REQUIREMENTS = Path(__file__).resolve().parent.parent / "requirements.txt"
+# First requests release that fixes CVE-2024-47081.
+CVE_FIXED = (2, 32, 4)
+
+
+def _parse_version(text: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in text.strip().split("."))
+
+
+def _requests_pin() -> tuple[str, tuple[int, ...]]:
+    """Return the (operator, version) of the requests pin in requirements.txt."""
+    for line in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name = re.split(r"[=<>!~ ]", line, maxsplit=1)[0].split("[", 1)[0].lower()
+        if name == "requests":
+            match = re.search(r"(==|>=|~=|<|<=|>|!=)\s*(\d+(?:\.\d+)*)", line)
+            if match:
+                return match.group(1), _parse_version(match.group(2))
+            raise AssertionError(f"requests has no version pin in requirements.txt: {line!r}")
+    raise AssertionError("requests is not pinned in requirements.txt")
+
+
+def test_requests_pin_not_affected_by_cve_2024_47081() -> None:
+    operator, version = _requests_pin()
+    if operator in ("==", ">=", "~=") and version >= CVE_FIXED:
+        return
+    if operator == ">" and version >= (2, 32, 3):
+        # ">2.32.3" already excludes 2.32.3, so only fixed releases can be resolved.
+        return
+    raise AssertionError(
+        f"requests pin {operator}{'.'.join(map(str, version))} can still resolve to a "
+        "version affected by CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7); bump to "
+        "requests>=2.32.4"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        test_requests_pin_not_affected_by_cve_2024_47081()
+    except AssertionError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print("OK: requests pin is not affected by CVE-2024-47081")


### PR DESCRIPTION
## Summary

Fixes #1184

`requirements.txt` still pins `requests==2.32.3`, which is affected by CVE-2024-47081 (GHSA-9hjg-9r4m-mvj7): requests before 2.32.4 can leak `.netrc` credentials to a different host when following a redirect to a URL carrying userinfo. This bumps the pin to `requests==2.32.4`, the first patched release. `==2.32.4` satisfies the advisory's `>=2.32.4` requirement while keeping the exact-pin style used throughout the file.

## Verification

Added a regression test `tests/test_requests_cve_1184.py` that asserts the requests pin in `requirements.txt` cannot resolve to a version affected by CVE-2024-47081.

- Before the fix (pin `==2.32.3`): the test fails with `requests pin ==2.32.3 can still resolve to a version affected by CVE-2024-47081 ...` (exit code 1).
- After the fix (pin `==2.32.4`): the test passes (`OK: requests pin is not affected by CVE-2024-47081`, exit code 0).

The test is dependency-free (Python stdlib only) and runs both standalone (`python3 tests/test_requests_cve_1184.py`) and under pytest.

## Notes

- No competing PR for this issue was found, and the issue is currently unclaimed.
- This is intentionally a minimal, dependency-pin-only change scoped to the reported CVE; the full upstream test suite was not run.