### PR TITLE
docs: mention Atlas Cloud as an OpenAI-compatible endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ After you have Python and (optionally) PostgreSQL installed, follow these steps:
 5. `pip install -r requirements.txt` (install the dependencies)
 6. `cp example-config.json config.json` (create `config.json` file)
 7. Set your key and other settings in `config.json` file:
-   - LLM Provider (`openai`, `anthropic` or `groq`) key and endpoints (leave `null` for default) (note that Azure and OpenRouter are suppored via the `openai` setting)
+   - LLM Provider (`openai`, `anthropic` or `groq`) key and endpoints (leave `null` for default) (note that Azure, OpenRouter and other OpenAI-compatible endpoints such as [Atlas Cloud](https://www.atlascloud.ai/) are supported via the `openai` setting)
    - Your API key (if `null`, will be read from the environment variables)
    - database settings: sqlite is used by default, PostgreSQL should also work
    - optionally update `fs.ignore_paths` and add files or folders which shouldn't be tracked by GPT Pilot in workspace, useful to ignore folders created by compilers

--- a/example-config.json
+++ b/example-config.json
@@ -1,7 +1,7 @@
 {
   // Configuration for the LLM providers that can be used. Pythagora supports
-  // OpenAI, Azure, Anthropic and Groq. OpenRouter and local LLMs (such as LM-Studio)
-  // also work, you can use "openai" provider to define these.
+  // OpenAI, Azure, Anthropic and Groq. OpenRouter, Atlas Cloud and local LLMs
+  // (such as LM-Studio) also work, you can use "openai" provider to define these.
   "llm": {
     "openai": {
       // Base url to the provider/server, omitting the trailing "chat/completions" part.
@@ -17,6 +17,17 @@
       "connect_timeout": 60.0,
       "read_timeout": 20.0
     },
+    // Example config for an OpenAI-compatible endpoint such as Atlas Cloud
+    // (see https://www.atlascloud.ai/docs). Any provider that speaks the
+    // OpenAI chat-completions API goes under "openai" with its own base_url;
+    // pair it with an agent config that names one of its models, e.g.
+    // "provider": "openai", "model": "deepseek-ai/deepseek-v4-pro".
+    // "openai": {
+    //   "base_url": "https://api.atlascloud.ai/v1",
+    //   "api_key": "your-api-key",
+    //   "connect_timeout": 60.0,
+    //   "read_timeout": 20.0
+    // },
     // Example config for Azure OpenAI (see https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions)
     "azure": {
       "base_url": "https://your-resource-name.openai.azure.com/",


### PR DESCRIPTION
## Summary

Documents **Atlas Cloud** as an OpenAI-compatible endpoint. **No new provider enum, no new client** —
because the project already has a documented path for this:

> README: *"note that Azure and OpenRouter are suppored via the `openai` setting"*
> example-config.json: *"OpenRouter and local LLMs (such as LM-Studio) also work, you can use
> `openai` provider to define these."*

Atlas Cloud works through exactly that path, so adding an `LLMProvider` member plus a client class
would duplicate `OpenAIClient` for no behavioural gain. This PR just makes the existing capability
discoverable.

## Changes

- `example-config.json` — extend the header comment, and add a **commented example block** beside
  the Azure/Anthropic ones. It includes the agent-side model id too, so the snippet is
  copy-pasteable rather than half a config.
- `README.md` — name it in the provider line next to Azure and OpenRouter.

## Validation

Checked against the live endpoint **using this project's request shape**, not a generic curl: the
OpenAI SDK pointed at `https://api.atlascloud.ai/v1` with `stream=True` and a temperature — which is
what `core/llm/openai_client.py` sends — streams content back normally.

`example-config.json` still parses as JSON once the `//` comments are stripped, so the
`cp example-config.json config.json` flow in the README is unaffected.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the note above, we'd love to explore a closer collaboration with **GPT Pilot / Pythagora** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->
